### PR TITLE
feat(actions): implement question-based action filtering and automatic creation

### DIFF
--- a/src/lib/components/cards/QuestionCard.svelte
+++ b/src/lib/components/cards/QuestionCard.svelte
@@ -22,7 +22,8 @@
 		responseInput: null,
 		actionsInput: null,
 		actionType: '',
-		responseId: null
+		responseId: null,
+		visibility: 'private'
 	});
 
 	$inspect(questionDetails.responseId).with((type, value) =>
@@ -70,7 +71,7 @@
 
 		questionDetails = details;
 		if (details.actionType !== '') actionType = details.actionType;
-
+		visibility = details.visibility || 'private';
 		const result = {
 			queryId: questionId,
 			question: question || null,
@@ -83,7 +84,7 @@
 		return result;
 	};
 
-	let visibility = $state('private');
+	let visibility = $state(questionDetails.visibility || 'private');
 	const toggleVisibility = () => {
 		visibility = visibility === 'public' ? 'private' : 'public';
 	};

--- a/src/lib/components/cards/QuestionCard.svelte
+++ b/src/lib/components/cards/QuestionCard.svelte
@@ -13,7 +13,6 @@
 	const profileId = $derived(app.profile.id);
 	const category = $derived(app.list.category);
 
-	let actionType = $state('');
 
 	// Targets
 	// TODO This should be read from appState context
@@ -70,7 +69,6 @@
 		console.log('📝 Question details:', details);
 
 		questionDetails = details;
-		if (details.actionType !== '') actionType = details.actionType;
 		// Update visibility based on details or default to 'private'
 		visibility = details.visibility || 'private';
 		const result = {
@@ -124,7 +122,7 @@
 
 				<label for="question-{questionId}-action-type" class="text-md"> Action type: </label>
 
-				<select id="question-{questionId}-action-type" bind:value={actionType} class="form-select">
+				<select id="question-{questionId}-action-type" bind:value={questionDetails.actionType} class="form-select">
 					<option value="default" selected>Action type</option>
 					<option value="workplace_adjustment">Workplace adjustment</option>
 					<option value="schedule_adjustment">Schedule adjustment</option>

--- a/src/lib/components/cards/QuestionCard.svelte
+++ b/src/lib/components/cards/QuestionCard.svelte
@@ -71,6 +71,7 @@
 
 		questionDetails = details;
 		if (details.actionType !== '') actionType = details.actionType;
+		// Update visibility based on details or default to 'private'
 		visibility = details.visibility || 'private';
 		const result = {
 			queryId: questionId,
@@ -84,7 +85,7 @@
 		return result;
 	};
 
-	let visibility = $state(questionDetails.visibility || 'private');
+	let visibility = $state('private');
 	const toggleVisibility = () => {
 		visibility = visibility === 'public' ? 'private' : 'public';
 	};

--- a/src/lib/components/ui/FormButton.svelte
+++ b/src/lib/components/ui/FormButton.svelte
@@ -68,17 +68,17 @@
 				try {
 					const result = await createResponse(profileId, responseData);
 					console.log('✅ Response created successfully:', result);
-					
+
 					// If user provided action data, create an action linked to this response
-					if (hasActionData && result.data?.id) {
+					if (hasActionData() && result.data?.id) {
 						const actionData = {
 							type: details?.actionType || '',
 							description: details?.actionsInput,
 							response_id: result.data.id
 						};
-						
+
 						console.log('🎯 Creating action after response:', actionData);
-						
+
 						try {
 							const actionResult = await createAction(profileId, actionData);
 							console.log('✅ Action created successfully:', actionResult);

--- a/src/lib/components/ui/FormButton.svelte
+++ b/src/lib/components/ui/FormButton.svelte
@@ -24,6 +24,14 @@
 	const profileId = $derived(getProfileId());
 	const questionId = $derived(getQuestionId());
 
+	// Helper function to check if user provided action data
+	const hasActionData = $derived(() => {
+		const hasType =
+			details?.actionType && details.actionType !== '' && details.actionType !== 'default';
+		const hasDescription = details?.actionsInput && details.actionsInput.trim() !== '';
+		return hasType && hasDescription;
+	});
+
 	function clear() {
 		setViewName('list');
 		setQuestionId(null);
@@ -60,6 +68,24 @@
 				try {
 					const result = await createResponse(profileId, responseData);
 					console.log('✅ Response created successfully:', result);
+					
+					// If user provided action data, create an action linked to this response
+					if (hasActionData && result.data?.id) {
+						const actionData = {
+							type: details?.actionType || '',
+							description: details?.actionsInput,
+							response_id: result.data.id
+						};
+						
+						console.log('🎯 Creating action after response:', actionData);
+						
+						try {
+							const actionResult = await createAction(profileId, actionData);
+							console.log('✅ Action created successfully:', actionResult);
+						} catch (actionError) {
+							console.error('❌ Action creation failed:', actionError);
+						}
+					}
 				} catch (error) {
 					console.error('❌ Response creation failed:', error);
 				}

--- a/src/lib/services/database/actions.ts
+++ b/src/lib/services/database/actions.ts
@@ -277,7 +277,7 @@ export async function archiveAction(id: string): Result<Action> {
 export async function getLatestActions(userId: string): Results<Action> {
 	const { data, error } = await supabase
 		.from('actions')
-		.select('*')
+		.select('*, responses!inner(question_id)')
 		.eq('user_id', userId)
 		.order('created_at', { ascending: false });
 
@@ -296,7 +296,8 @@ export async function getLatestActions(userId: string): Results<Action> {
 			version: dbAction.version || 1,
 			status: dbAction.status as 'active' | 'archived',
 			created_at: dbAction.created_at || undefined,
-			updated_at: dbAction.updated_at || undefined
+			updated_at: dbAction.updated_at || undefined,
+			question_id: dbAction.responses?.question_id || ''
 		})) || null;
 
 	// Use utility function to get latest versions

--- a/src/lib/types/appState.ts
+++ b/src/lib/types/appState.ts
@@ -45,6 +45,7 @@ export interface QuestionDetails {
 	actionsInput: string | null;
 	actionType: string;
 	responseId: RowId | null;
+	visibility: 'public' | 'private';
 }
 
 export type RowId = string;

--- a/src/lib/types/tableMain.ts
+++ b/src/lib/types/tableMain.ts
@@ -6,6 +6,7 @@ export interface Action {
 	id?: string;
 	user_id: string;
 	response_id?: string;
+	question_id?: string;
 	type: string;
 	description?: string;
 	version: number;

--- a/src/lib/utils/getContent.svelte.ts
+++ b/src/lib/utils/getContent.svelte.ts
@@ -26,7 +26,8 @@ export const getQuestionDetails = async (
 		responseInput: questionResponse?.response_text || null,
 		actionsInput: previousAction?.description || null,
 		actionType: previousAction?.type || '',
-		responseId: questionResponse?.id || null
+		responseId: questionResponse?.id || null,
+		visibility: questionResponse?.visibility || 'private'
 	};
 
 	console.log('📤 Returning question details:', result);

--- a/src/lib/utils/versionFilter.ts
+++ b/src/lib/utils/versionFilter.ts
@@ -54,7 +54,7 @@ export function filterLatestResponses(responses: Response[]): Response[] {
 export function filterLatestActions(actions: Action[]): Action[] {
 	const latestActionsMap = new Map<string, Action>();
 	for (const action of actions) {
-		const key = `${action.user_id}-${action.response_id}`;
+		const key = `${action.user_id}-${(action as any).question_id}`;
 		const existing = latestActionsMap.get(key);
 
 		// Validate creation date data integrity

--- a/src/lib/utils/versionFilter.ts
+++ b/src/lib/utils/versionFilter.ts
@@ -54,7 +54,9 @@ export function filterLatestResponses(responses: Response[]): Response[] {
 export function filterLatestActions(actions: Action[]): Action[] {
 	const latestActionsMap = new Map<string, Action>();
 	for (const action of actions) {
-		const key = `${action.user_id}-${(action as any).question_id}`;
+		const userId = action.user_id;
+		const questionId = action.question_id || '';
+		const key = userId + '-' + questionId;
 		const existing = latestActionsMap.get(key);
 
 		// Validate creation date data integrity


### PR DESCRIPTION
## Overview

Refactors the actions system to use question-based filtering instead of response-based filtering and implements automatic action creation when users submit responses with action data.

---

## Changes

**Action Filtering System**
- Changed actions filtering from response-based to question-based approach
- Updated `filterLatestActions` to use `user_id + question_id` as key instead of `user_id + response_id`
- Added optional `question_id` field to Action type for improved filtering logic
- Modified `getLatestActions` to include question_id from joined responses table

**Automatic Action Creation**
- Implemented automatic action creation when users submit responses with action data
- Added logic in FormButton to detect when user provides both action type and description
- Creates linked action record immediately after successful response creation
- Maintains data integrity by linking actions to their parent responses

**UI/State Management**
- Fixed Svelte 5 reactivity warnings for visibility state management
- Restored response privacy state when loading existing responses
- Improved question details handling with proper visibility defaults
- Cleaned up redundant state variables in QuestionCard component

**Data Integrity**
- Enhanced `getQuestionDetails` to properly restore visibility state
- Added proper error handling for action creation failures
- Maintained backward compatibility with existing action records

---

## Summary

Like upgrading from a filing cabinet organized by individual papers to one organized by topic folders - actions now group by the questions they address rather than scattered across response documents, while also automatically creating new files when someone fills out a form completely.

🤖 Generated with [Claude Code](https://claude.ai/code)