### PR TITLE
feat(ui): add delete confirmation modal for response management

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
   "prettier.prettierPath": "./node_modules/prettier",
   "[markdown]": {
     "editor.defaultFormatter": "yzhang.markdown-all-in-one"
-  }
+  },
+  "postman.settings.dotenv-detection-notification-visibility": false
 }

--- a/src/lib/components/cards/QuestionCard.svelte
+++ b/src/lib/components/cards/QuestionCard.svelte
@@ -31,11 +31,9 @@
 		setQuestionId(null);
 	};
 
-	const handleDeleteConfirm = async () => {
+	const deleteResponse = async () => {
 		if (!profileId) {
-			console.error('Cannot delete response without a profile ID.');
-			closeDeleteModal();
-			return;
+			throw new Error('Cannot delete response without a profile ID.');
 		}
 
 		const responseData = {
@@ -46,15 +44,8 @@
 		};
 
 		console.log('🎯 Deleting response:', responseData);
-
-		try {
-			await createResponse(profileId, responseData);
-			console.log('✅ Response deleted successfully:');
-		} catch (error) {
-			console.error('❌ Response deletion failed:', error);
-		}
-		closeDeleteModal();
-		clearDetail();
+		await createResponse(profileId, responseData);
+		console.log('✅ Response deleted successfully:');
 	};
 
 	// TODO This should be read from appState context
@@ -155,7 +146,8 @@
 	show={showDeleteModal}
 	title="Confirm Deletion"
 	message="Are you sure you want to delete this response? This action cannot be undone."
-	onConfirm={handleDeleteConfirm}
+	onConfirm={deleteResponse}
+	onSuccess={clearDetail}
 	onCancel={closeDeleteModal}
 />
 

--- a/src/lib/components/cards/QuestionCard.svelte
+++ b/src/lib/components/cards/QuestionCard.svelte
@@ -2,7 +2,7 @@
 	import { getQuestionById, createResponse } from '$lib/services/database';
 	import FormButton from '../ui/FormButton.svelte';
 	import ToggleStatus from '../ui/ToggleStatus.svelte';
-	import type { TableName, QuestionConnections } from '$lib/types/appState';
+	import type { TableName, QuestionConnections, RowId, ViewName } from '$lib/types/appState';
 	import { getQuestionConnections } from '$lib/utils/getContent.svelte';
 	import { getContext } from 'svelte';
 	import type { AppState } from '$lib/types/appState';
@@ -23,7 +23,15 @@
 		showDeleteModal = false;
 	};
 
-	const handleDeleteConfirm = () => {
+	const setQuestionId = getContext<(newDetail: RowId | null) => void>('setDetailItemId');
+	const setViewName = getContext<(view: ViewName) => void>('setViewName');
+
+	const clearDetail = () => {
+		setViewName('list');
+		setQuestionId(null);
+	};
+
+	const handleDeleteConfirm = async () => {
 		if (!profileId) {
 			console.error('Cannot delete response without a profile ID.');
 			closeDeleteModal();
@@ -40,12 +48,13 @@
 		console.log('🎯 Deleting response:', responseData);
 
 		try {
-			createResponse(profileId, responseData);
+			await createResponse(profileId, responseData);
 			console.log('✅ Response deleted successfully:');
 		} catch (error) {
 			console.error('❌ Response deletion failed:', error);
 		}
 		closeDeleteModal();
+		clearDetail();
 	};
 
 	// TODO This should be read from appState context

--- a/src/lib/components/cards/QuestionCard.svelte
+++ b/src/lib/components/cards/QuestionCard.svelte
@@ -1,17 +1,52 @@
 <script lang="ts">
-	import { getQuestionById } from '$lib/services/database';
+	import { getQuestionById, createResponse } from '$lib/services/database';
 	import FormButton from '../ui/FormButton.svelte';
 	import ToggleStatus from '../ui/ToggleStatus.svelte';
 	import type { TableName, QuestionConnections } from '$lib/types/appState';
 	import { getQuestionConnections } from '$lib/utils/getContent.svelte';
 	import { getContext } from 'svelte';
 	import type { AppState } from '$lib/types/appState';
+	import ConfirmModal from '../ui/ConfirmModal.svelte';
 
 	// App State
 	const getApp = getContext<() => AppState>('getApp');
 	const app = $derived(getApp());
 	const profileId = $derived(app.profile.id);
 
+	let showDeleteModal = $state(false);
+
+	const openDeleteModal = () => {
+		showDeleteModal = true;
+	};
+
+	const closeDeleteModal = () => {
+		showDeleteModal = false;
+	};
+
+	const handleDeleteConfirm = () => {
+		if (!profileId) {
+			console.error('Cannot delete response without a profile ID.');
+			closeDeleteModal();
+			return;
+		}
+
+		const responseData = {
+			response_text: null,
+			question_id: questionId,
+			status: 'skipped',
+			visibility: 'private' // Force private for skipped/deleted responses
+		};
+
+		console.log('🎯 Deleting response:', responseData);
+
+		try {
+			createResponse(profileId, responseData);
+			console.log('✅ Response deleted successfully:');
+		} catch (error) {
+			console.error('❌ Response deletion failed:', error);
+		}
+		closeDeleteModal();
+	};
 
 	// TODO This should be read from appState context
 	let table: TableName = $state('responses');
@@ -32,14 +67,14 @@
 
 	const hasResponseContent = $derived(
 		connectionDetails.responseInput !== null &&
-		connectionDetails.responseInput !== undefined &&
-		connectionDetails.responseInput.trim() !== ''
+			connectionDetails.responseInput !== undefined &&
+			connectionDetails.responseInput.trim() !== ''
 	);
 
 	const hasActionContent = $derived(
 		connectionDetails.actionsInput !== null &&
-		connectionDetails.actionsInput !== undefined &&
-		connectionDetails.actionsInput.trim() !== ''
+			connectionDetails.actionsInput !== undefined &&
+			connectionDetails.actionsInput.trim() !== ''
 	);
 
 	const buttonConfig = $derived(() => {
@@ -49,8 +84,12 @@
 	});
 
 	$inspect(isUpdate).with((type, value) => console.log(`🔄 isUpdate: ${type} ${value}`));
-	$inspect(hasResponseContent).with((type, value) => console.log(`📝 hasResponseContent: ${type} ${value}`));
-	$inspect(hasActionContent).with((type, value) => console.log(`📝 hasActionContent: ${type} ${value}`));
+	$inspect(hasResponseContent).with((type, value) =>
+		console.log(`📝 hasResponseContent: ${type} ${value}`)
+	);
+	$inspect(hasActionContent).with((type, value) =>
+		console.log(`📝 hasActionContent: ${type} ${value}`)
+	);
 	$inspect(buttonConfig().primaryText).with((type, value) =>
 		console.log(`🔘 Button 1: ${type} ${value}`)
 	);
@@ -76,7 +115,7 @@
 		console.log('📝 Connections:', connections);
 
 		connectionDetails = connections;
-		
+
 		// Update visibility based on details or default to 'private'
 		visibility = connections.visibility || 'private';
 		connectionDetails.actionsInput = null;
@@ -94,12 +133,22 @@
 	};
 
 	let visibility = $state('private');
-	$inspect(visibility).with((type, value) => console.log(`📝 visibility (local): ${type} ${value}`));
-	
+	$inspect(visibility).with((type, value) =>
+		console.log(`📝 visibility (local): ${type} ${value}`)
+	);
+
 	const toggleVisibility = () => {
 		visibility = visibility === 'public' ? 'private' : 'public';
 	};
 </script>
+
+<ConfirmModal
+	show={showDeleteModal}
+	title="Confirm Deletion"
+	message="Are you sure you want to delete this response? This action cannot be undone."
+	onConfirm={handleDeleteConfirm}
+	onCancel={closeDeleteModal}
+/>
 
 <section id="question-{questionId}" class="view-layout">
 	{#await getData()}
@@ -163,6 +212,7 @@
 					{hasActionContent}
 					details={connectionDetails}
 					{visibility}
+					onclick={isUpdate ? openDeleteModal : undefined}
 				/>
 			</div>
 		{:else}

--- a/src/lib/components/ui/ConfirmModal.svelte
+++ b/src/lib/components/ui/ConfirmModal.svelte
@@ -11,7 +11,14 @@
 </script>
 
 {#if show}
-	<dialog class="modal modal-open">
+	<dialog
+		class="modal modal-open"
+		onclick={(event) => {
+			if (event.currentTarget === event.target) {
+				onCancel();
+			}
+		}}
+	>
 		<div class="modal-box">
 			<h3 class="font-bold text-lg">{title}</h3>
 			<p class="py-4">{message}</p>

--- a/src/lib/components/ui/ConfirmModal.svelte
+++ b/src/lib/components/ui/ConfirmModal.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	interface Props {
+		show: boolean;
+		title: string;
+		message: string;
+		onConfirm: () => void;
+		onCancel: () => void;
+	}
+
+	let { show, title, message, onConfirm, onCancel }: Props = $props();
+</script>
+
+{#if show}
+	<dialog class="modal modal-open">
+		<div class="modal-box">
+			<h3 class="font-bold text-lg">{title}</h3>
+			<p class="py-4">{message}</p>
+			<div class="modal-action">
+				<button class="btn" onclick={onCancel}>Cancel</button>
+				<button class="btn btn-primary" onclick={onConfirm}>Confirm</button>
+			</div>
+		</div>
+	</dialog>
+{/if}

--- a/src/lib/components/ui/ConfirmModal.svelte
+++ b/src/lib/components/ui/ConfirmModal.svelte
@@ -9,8 +9,8 @@
 
 	let { show, title, message, onConfirm, onCancel }: Props = $props();
 
-	let dialog: HTMLDialogElement;
-	let previouslyFocused: HTMLElement | null;
+	let dialog = $state<HTMLDialogElement>();
+	let previouslyFocused = $state<HTMLElement | null>(null);
 
 	$effect(() => {
 		if (show && dialog) {
@@ -28,6 +28,7 @@
 	});
 
 	function handleKeydown(e: KeyboardEvent) {
+		if (!dialog) return;
 		if (e.key === 'Tab') {
 			const focusable = Array.from(
 				dialog.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')

--- a/src/lib/components/ui/ConfirmModal.svelte
+++ b/src/lib/components/ui/ConfirmModal.svelte
@@ -10,6 +10,13 @@
 	let { show, title, message, onConfirm, onCancel }: Props = $props();
 </script>
 
+<svelte:window
+	on:keydown={(e) => {
+		if (show && e.key === 'Escape') {
+			onCancel();
+		}
+	}}
+/>
 {#if show}
 	<dialog
 		class="modal modal-open"
@@ -20,7 +27,7 @@
 		}}
 	>
 		<div class="modal-box">
-			<h3 class="font-bold text-lg">{title}</h3>
+			<h3 class="text-lg font-bold">{title}</h3>
 			<p class="py-4">{message}</p>
 			<div class="modal-action">
 				<button class="btn" onclick={onCancel}>Cancel</button>

--- a/src/lib/components/ui/ConfirmModal.svelte
+++ b/src/lib/components/ui/ConfirmModal.svelte
@@ -8,10 +8,46 @@
 	}
 
 	let { show, title, message, onConfirm, onCancel }: Props = $props();
+
+	let dialog: HTMLDialogElement;
+	let previouslyFocused: HTMLElement | null;
+
+	$effect(() => {
+		if (show && dialog) {
+			previouslyFocused = document.activeElement as HTMLElement;
+			dialog.showModal();
+			const autofocusElement = dialog.querySelector<HTMLElement>('[data-autofocus]');
+			if (autofocusElement) {
+				autofocusElement.focus();
+			}
+		} else if (!show && dialog && previouslyFocused) {
+			dialog.close();
+			previouslyFocused.focus();
+			previouslyFocused = null;
+		}
+	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Tab') {
+			const focusable = Array.from(
+				dialog.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+			) as HTMLElement[];
+			const first = focusable[0];
+			const last = focusable[focusable.length - 1];
+
+			if (e.shiftKey && document.activeElement === first) {
+				last.focus();
+				e.preventDefault();
+			} else if (!e.shiftKey && document.activeElement === last) {
+				first.focus();
+				e.preventDefault();
+			}
+		}
+	}
 </script>
 
 <svelte:window
-	on:keydown={(e) => {
+	onkeydown={(e) => {
 		if (show && e.key === 'Escape') {
 			onCancel();
 		}
@@ -19,19 +55,21 @@
 />
 {#if show}
 	<dialog
-		class="modal modal-open"
+		bind:this={dialog}
+		class="modal"
 		onclick={(event) => {
 			if (event.currentTarget === event.target) {
 				onCancel();
 			}
 		}}
+		onkeydown={handleKeydown}
 	>
 		<div class="modal-box">
 			<h3 class="text-lg font-bold">{title}</h3>
 			<p class="py-4">{message}</p>
 			<div class="modal-action">
 				<button class="btn" onclick={onCancel}>Cancel</button>
-				<button class="btn btn-primary" onclick={onConfirm}>Confirm</button>
+				<button class="btn btn-primary" onclick={onConfirm} data-autofocus>Confirm</button>
 			</div>
 		</div>
 	</dialog>

--- a/src/lib/components/ui/FormButton.svelte
+++ b/src/lib/components/ui/FormButton.svelte
@@ -13,9 +13,20 @@
 		isUpdate: boolean;
 		hasResponseContent: boolean;
 		hasActionContent: boolean;
+		onclick?: () => void;
 	}
 
-	let { buttonType, details, hasResponseContent, hasActionContent, isUpdate, table, text, visibility }: Props = $props();
+	let {
+		buttonType,
+		details,
+		hasResponseContent,
+		hasActionContent,
+		isUpdate,
+		table,
+		text,
+		visibility,
+		onclick
+	}: Props = $props();
 
 	const getProfileId = getContext<() => string>('getProfileId');
 	const getQuestionId = getContext<() => string>('getDetailItemId');
@@ -37,7 +48,12 @@
 		setQuestionId(null);
 	}
 
-	const onclick = async () => {
+	const handleClick = async () => {
+		if (onclick) {
+			onclick();
+			return;
+		}
+
 		console.groupCollapsed(`🔘 FormButton Click: ${text}`);
 		console.log('📋 Button Props:', {
 			text,
@@ -74,7 +90,7 @@
 					if (hasActionContent && result.data?.id) {
 						const actionData = {
 							description: details?.actionsInput,
-							type: "",
+							type: '',
 							response_id: result.data.id
 						};
 
@@ -136,6 +152,6 @@
 	};
 </script>
 
-<button {onclick} type="submit" class="btn-submit">
+<button onclick={handleClick} type="submit" class="btn-submit">
 	{text}
 </button>


### PR DESCRIPTION
## Overview

Adds user-friendly response deletion functionality with confirmation modal to prevent accidental data loss. When users update responses, they can now safely delete them through a clear confirmation workflow.

---

## Changes

**New Components**
- Added `ConfirmModal.svelte` - Reusable confirmation dialog with DaisyUI styling
- Supports click-outside-to-close functionality for better UX

**Enhanced Question Management**
- Added delete confirmation workflow to `QuestionCard.svelte`
- Integrated async delete handling with proper error management
- Automatic navigation back to list view after deletion
- Delete creates "skipped" response to maintain audit trail

**Form Button Improvements**
- Enhanced `FormButton.svelte` with optional custom click handlers
- Maintains backward compatibility with existing button logic
- Supports both default form submission and custom actions

**Technical Implementation**
- Uses project's versioning system (creates new "skipped" response vs hard delete)
- Proper async/await error handling
- Context-based navigation using existing app state patterns
- Follows DaisyUI modal conventions

---