### PR TITLE
feat(auth): implement magic link authentication with profile management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,29 @@ Before submitting any code, ensure the following steps are completed:
 
 ## Deployment (Vercel)
 
+### IMPORTANT: Production Deployment Rules
+
+⚠️ **CRITICAL**: Production (`https://lift02.vercel.app`) is MANUALLY controlled. DO NOT deploy to production accidentally.
+
+**Deployment Commands:**
+
+```bash
+# PREVIEW deployment (safe - for testing)
+npm run deploy
+# or
+npx vercel
+
+# PRODUCTION deployment (MANUAL ONLY - requires explicit approval)
+npx vercel --prod
+```
+
+**Safe Workflow:**
+1. Work on feature branches (e.g., `feat/implement_auth`)
+2. Use `npm run deploy` to create preview deployments for testing
+3. Preview deployments get unique URLs like `https://lift02-xyz123.vercel.app`
+4. Only deploy to production after explicit approval
+5. Production is controlled from `main` branch only
+
 ### Environment Variables Setup
 
 Set these environment variables in Vercel dashboard (Settings > Environment Variables):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
 	"name": "workwise",
-	"version": "0.6.008",
+	"version": "0.6.026",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "workwise",
-			"version": "0.6.008",
+			"version": "0.6.026",
 			"dependencies": {
 				"@fontsource/metropolis": "^5.2.5",
+				"@supabase/ssr": "^0.7.0",
 				"@supabase/supabase-js": "^2.49.8",
 				"@tailwindcss/vite": "^4.1.10",
 				"daisyui": "^5.0.43",
@@ -37,7 +38,7 @@
 				"prettier-plugin-sql": "^0.19.1",
 				"prettier-plugin-svelte": "^3.3.3",
 				"prettier-plugin-tailwindcss": "^0.6.12",
-				"supabase": "^2.40.7",
+				"supabase": "^2.53.6",
 				"svelte": "^5.0.0",
 				"svelte-check": "^4.0.0",
 				"svelte-hero-icons": "^5.2.0",
@@ -1424,6 +1425,25 @@
 				"@types/phoenix": "^1.6.6",
 				"@types/ws": "^8.18.1",
 				"ws": "^8.18.2"
+			}
+		},
+		"node_modules/@supabase/ssr": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.7.0.tgz",
+			"integrity": "sha512-G65t5EhLSJ5c8hTCcXifSL9Q/ZRXvqgXeNo+d3P56f4U1IxwTqjB64UfmfixvmMcjuxnq2yGqEWVJqUcO+AzAg==",
+			"dependencies": {
+				"cookie": "^1.0.2"
+			},
+			"peerDependencies": {
+				"@supabase/supabase-js": "^2.43.4"
+			}
+		},
+		"node_modules/@supabase/ssr/node_modules/cookie": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+			"integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@supabase/storage-js": {
@@ -5915,16 +5935,16 @@
 			"license": "MIT"
 		},
 		"node_modules/supabase": {
-			"version": "2.45.5",
-			"resolved": "https://registry.npmjs.org/supabase/-/supabase-2.45.5.tgz",
-			"integrity": "sha512-/toOX6bHYx2TUNA5AtlzrKKfvctbLQ8R6QqvUCAT20KtZOkR14HpBYav3TNDaU5owPeB58cT5Uftvxw36Tb95A==",
+			"version": "2.53.6",
+			"resolved": "https://registry.npmjs.org/supabase/-/supabase-2.53.6.tgz",
+			"integrity": "sha512-tvMSykcxBaFm2SAKx93h6h4HjfJnWZV0kxO2P3i491Mtnu/95knLjSxr5gu7/tAJtPFuEMG/0m1kNGOHPSE6YA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
 				"bin-links": "^5.0.0",
 				"https-proxy-agent": "^7.0.2",
 				"node-fetch": "^3.3.2",
-				"tar": "7.4.4"
+				"tar": "7.5.1"
 			},
 			"bin": {
 				"supabase": "bin/supabase"
@@ -6095,9 +6115,9 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.4.4.tgz",
-			"integrity": "sha512-O1z7ajPkjTgEgmTGz0v9X4eqeEXTDREPTO77pVC1Nbs86feBU1Zhdg+edzavPmYW1olxkwsqA2v4uOw6E8LeDg==",
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
+			"integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
 				"chownr": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"prettier-plugin-sql": "^0.19.1",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.6.12",
-		"supabase": "^2.40.7",
+		"supabase": "^2.53.6",
 		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
 		"svelte-hero-icons": "^5.2.0",
@@ -51,6 +51,7 @@
 	},
 	"dependencies": {
 		"@fontsource/metropolis": "^5.2.5",
+		"@supabase/ssr": "^0.7.0",
 		"@supabase/supabase-js": "^2.49.8",
 		"@tailwindcss/vite": "^4.1.10",
 		"daisyui": "^5.0.43",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -38,10 +38,13 @@ echo "📝 Committing version change..."
 git add "package.json" "src/lib/version.ts"
 git commit -m "chore: bump version to $NEW_VERSION" || echo "⚠️  No changes to commit"
 
-echo "🏗️  Building and deploying to production..."
+echo "🏗️  Building and deploying to PREVIEW (not production)..."
 
-# Deploy to Vercel
-npx vercel --prod
+# Deploy to Vercel PREVIEW (not production)
+# IMPORTANT: We deploy to preview only. Production is manually controlled.
+npx vercel
 
 echo "🎉 Deployment completed! New version: $NEW_VERSION"
-echo "🔗 Check your deployment at: https://lift02.vercel.app"
+echo "⚠️  This was deployed as a PREVIEW deployment (not production)"
+echo "🔗 Check the deployment URL from the vercel output above"
+echo "📌 To deploy to production, use: npx vercel --prod (manual only!)"

--- a/scripts/prod-seed-test-data.sh
+++ b/scripts/prod-seed-test-data.sh
@@ -112,7 +112,10 @@ PROFILES_JSON=$(echo "$TEST_DATA" | jq '[.users[] | {
     name: .name,
     pronouns: .pronouns,
     job_title: .job_title,
-    is_line_manager: .is_line_manager
+    is_line_manager: .is_line_manager,
+    email: .email,
+    line_manager_name: .line_manager_name,
+    line_manager_email: .line_manager_email
 }]')
 
 PROFILE_RESPONSE=$(curl -s -X POST "$API_URL/profiles" \

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,10 +1,17 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
+import type { Session, SupabaseClient } from '@supabase/supabase-js';
+
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
-		// interface PageData {}
+		interface Locals {
+			supabase: SupabaseClient;
+			getSession: () => Promise<Session | null>;
+		}
+		interface PageData {
+			session: Session | null;
+		}
 		// interface PageState {}
 		// interface Platform {}
 	}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,34 @@
+import { createServerClient } from '@supabase/ssr';
+import { type Handle } from '@sveltejs/kit';
+import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
+
+export const handle: Handle = async ({ event, resolve }) => {
+	event.locals.supabase = createServerClient(
+		PUBLIC_SUPABASE_URL,
+		PUBLIC_SUPABASE_ANON_KEY,
+		{
+			cookies: {
+				get: (key) => event.cookies.get(key),
+				set: (key, value, options) => {
+					event.cookies.set(key, value, { ...options, path: '/' });
+				},
+				remove: (key, options) => {
+					event.cookies.delete(key, { ...options, path: '/' });
+				}
+			}
+		}
+	);
+
+	event.locals.getSession = async () => {
+		const {
+			data: { session }
+		} = await event.locals.supabase.auth.getSession();
+		return session;
+	};
+
+	return resolve(event, {
+		filterSerializedResponseHeaders(name) {
+			return name === 'content-range';
+		}
+	});
+};

--- a/src/lib/components/cards/QuestionCard.svelte
+++ b/src/lib/components/cards/QuestionCard.svelte
@@ -4,6 +4,7 @@
 	import ToggleStatus from '../ui/ToggleStatus.svelte';
 	import SaveStatus from '../ui/SaveStatus.svelte';
 	import UndoButton from '../ui/UndoButton.svelte';
+	import Tooltip from '../ui/Tooltip.svelte';
 	import type { QuestionConnections, RowId, ViewName } from '$lib/types/appState';
 	import { getQuestionConnections } from '$lib/utils/getContent.svelte';
 	import { getContext } from 'svelte';
@@ -296,19 +297,20 @@
 				></textarea>
 
 				<div class="mt-2 flex items-center gap-2">
-					<button
-						onclick={saveResponse}
-						disabled={!hasChanges || isSaving}
-						class="btn-submit btn-sm"
-						title="Save response to database"
-					>
-						{#if isSaving}
-							<span class="loading loading-spinner loading-xs"></span>
-							Saving...
-						{:else}
-							OK
-						{/if}
-					</button>
+					<Tooltip text="Save response to database" position="top_right">
+						<button
+							onclick={saveResponse}
+							disabled={!hasChanges || isSaving}
+							class="btn-submit btn-sm"
+						>
+							{#if isSaving}
+								<span class="loading loading-spinner loading-xs"></span>
+								Saving...
+							{:else}
+								OK
+							{/if}
+						</button>
+					</Tooltip>
 					<UndoButton {canUndo} onclick={handleUndo} />
 				</div>
 				{#if saveError}
@@ -324,13 +326,14 @@
 
 			{#if connectionDetails.responseId}
 				<div class="mx-4 mt-2 mb-4 flex justify-end">
-					<button
-						onclick={openDeleteModal}
-						class="btn btn-error btn-sm"
-						title="Delete this response and all related actions"
-					>
-						Delete Response & Actions
-					</button>
+					<Tooltip text="Delete this response and all related actions" position="left">
+						<button
+							onclick={openDeleteModal}
+							class="btn btn-error btn-sm"
+						>
+							Delete Response & Actions
+						</button>
+					</Tooltip>
 				</div>
 			{/if}
 		{:else}

--- a/src/lib/components/layouts/Footer.svelte
+++ b/src/lib/components/layouts/Footer.svelte
@@ -4,6 +4,7 @@
 	import { getContext } from 'svelte';
 	import FontSizeControl from '../ui/FontSizeControl.svelte';
 	import HelpButton from '../ui/HelpButton.svelte';
+	import ProfileButton from '../ui/ProfileButton.svelte';
 
 	let { devMode } = $props();
 
@@ -15,6 +16,8 @@
 
 <footer class="footer">
 	<HelpButton />
+
+	<ProfileButton />
 
 	<FontSizeControl />
 </footer>

--- a/src/lib/components/layouts/Header.svelte
+++ b/src/lib/components/layouts/Header.svelte
@@ -4,6 +4,7 @@
 	import Tooltip from '../ui/Tooltip.svelte';
 	import { Icon, Envelope } from 'svelte-hero-icons';
 	import { version } from '$lib/version';
+	import { getUserResponses } from '$lib/services/database/responses';
 
 	const getApp = getContext<() => AppState>('getApp');
 	const app = $derived(getApp());
@@ -12,6 +13,21 @@
 
 	// Check if currently in email view
 	const isInEmailView = $derived(app.view.name === 'email');
+
+	// Check if user has any answered questions
+	let hasAnsweredQuestions = $state(false);
+
+	$effect(() => {
+		if (app.profile.id) {
+			getUserResponses(app.profile.id).then((result) => {
+				if (result.data) {
+					hasAnsweredQuestions = result.data.some(r => r.status === 'answered');
+				}
+			});
+		} else {
+			hasAnsweredQuestions = false;
+		}
+	});
 	const onProfileClick = () => {
 		// setViewName('profile');
 		console.log('Profile Clicked');
@@ -113,16 +129,25 @@
 			{/if}
 		</div>
 
-		<h1>Workwise</h1>
+		<div class="flex flex-col">
+			<h1>Workwise</h1>
+			{#if app.profile.name}
+				<span class="text-xs text-white opacity-70">Logged in as: {app.profile.name}</span>
+			{/if}
+		</div>
 	</div>
 
 	<div class="header-right">
 			<!-- Email Button -->
 			{#if app.profile.id}
-				<Tooltip
-					text={isInEmailView
+				{@const isDisabled = isInEmailView || !hasAnsweredQuestions}
+				{@const tooltipText = !hasAnsweredQuestions
+					? 'Answer at least one question to generate an email'
+					: isInEmailView
 						? 'Currently viewing email preview'
 						: 'Generate an email summary of your responses and actions to share with your line manager'}
+				<Tooltip
+					text={tooltipText}
 					position="bottom_left"
 				>
 					<button
@@ -131,12 +156,12 @@
 						class="w-10 h-10 rounded-full border-2 border-white bg-transparent flex items-center justify-center hover:bg-white hover:bg-opacity-20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
 						type="button"
 						aria-label="Send Email to Line Manager"
-						disabled={isInEmailView}
+						disabled={isDisabled}
 					>
 						<Icon
 							src={Envelope}
 							solid
-							class="h-5 w-5 transition-colors {isInEmailView
+							class="h-5 w-5 transition-colors {isDisabled
 								? 'text-white/40'
 								: 'text-white'}"
 						/>

--- a/src/lib/components/layouts/Header.svelte
+++ b/src/lib/components/layouts/Header.svelte
@@ -17,9 +17,14 @@
 	// Check if user has any answered questions
 	let hasAnsweredQuestions = $state(false);
 
+	// Re-check responses whenever view changes or profile loads
 	$effect(() => {
-		if (app.profile.id) {
-			getUserResponses(app.profile.id).then((result) => {
+		// Track view name and profile id to trigger re-check
+		const viewName = app.view.name;
+		const profileId = app.profile.id;
+
+		if (profileId) {
+			getUserResponses(profileId).then((result) => {
 				if (result.data) {
 					hasAnsweredQuestions = result.data.some(r => r.status === 'answered');
 				}

--- a/src/lib/components/ui/ActionsCRUD.svelte
+++ b/src/lib/components/ui/ActionsCRUD.svelte
@@ -9,6 +9,7 @@
 	import type { Action } from '$lib/types/tableMain';
 	import type { AppState } from '$lib/types/appState';
 	import ConfirmModal from './ConfirmModal.svelte';
+	import Tooltip from './Tooltip.svelte';
 
 	interface Props {
 		responseId: string | null;
@@ -320,14 +321,15 @@
 			</div>
 		</div>
 	{:else}
-		<button
-			onclick={() => (showNewActionForm = true)}
-			class="btn-submit btn-sm"
-			disabled={!responseId}
-			title={!responseId ? "Save your response first to add actions" : "Add a new action"}
-		>
-			Add Action
-		</button>
+		<Tooltip text={!responseId ? "Save your response first to add actions" : "Add a new action"} position="top_right">
+			<button
+				onclick={() => (showNewActionForm = true)}
+				class="btn-submit btn-sm"
+				disabled={!responseId}
+			>
+				Add Action
+			</button>
+		</Tooltip>
 		{#if !responseId}
 			<p class="text-sm text-base-content/70 mt-2">
 				💡 Save your response first to add actions

--- a/src/lib/components/ui/Breadcrumb.svelte
+++ b/src/lib/components/ui/Breadcrumb.svelte
@@ -16,7 +16,7 @@
 
 	// Track which breadcrumb items are on a wrapped line
 	let wrappedItems = $state<Set<number>>(new Set());
-	let breadcrumbList: HTMLElement | null = null;
+	let breadcrumbList = $state<HTMLElement | null>(null);
 
 	// Detect wrapped breadcrumb items
 	function checkWrapping() {

--- a/src/lib/components/ui/ProfileButton.svelte
+++ b/src/lib/components/ui/ProfileButton.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { Icon, User } from 'svelte-hero-icons';
+	import type { AppState } from '$lib/types/appState';
+	import Tooltip from './Tooltip.svelte';
+	import ProfileSettingsModal from './ProfileSettingsModal.svelte';
+
+	const getApp = getContext<() => AppState>('getApp');
+	const app = $derived(getApp());
+	const hasProfile = $derived(!!app.profile.id);
+
+	let showModal = $state(false);
+
+	function handleClick() {
+		showModal = true;
+	}
+
+	function handleClose() {
+		showModal = false;
+	}
+</script>
+
+{#if hasProfile}
+	<Tooltip text="Edit your profile settings" position="top">
+		<button
+			id="profile-button"
+			onclick={handleClick}
+			class="hover:bg-opacity-20 flex h-10 w-10 items-center justify-center rounded-full border-2 border-white bg-transparent text-white transition-colors hover:bg-white"
+			type="button"
+			aria-label="Profile Settings"
+		>
+			<Icon src={User} solid class="h-5 w-5" />
+		</button>
+	</Tooltip>
+
+	<ProfileSettingsModal show={showModal} onclose={handleClose} />
+{/if}

--- a/src/lib/components/ui/ProfileCompletionModal.svelte
+++ b/src/lib/components/ui/ProfileCompletionModal.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import type { Profile } from '$lib/types/appState';
+	import { updateProfile } from '$lib/services/database/profiles';
+
+	interface Props {
+		show: boolean;
+		onclose: () => void;
+		currentProfile: Profile;
+	}
+
+	let { show, onclose, currentProfile }: Props = $props();
+
+	const setProfile = getContext<(profile: Profile) => void>('setProfile');
+
+	let name = $state(currentProfile.name || '');
+	let lineManagerName = $state('');
+	let lineManagerEmail = $state('');
+	let loading = $state(false);
+	let error = $state<string | null>(null);
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		loading = true;
+		error = null;
+
+		try {
+			if (!currentProfile.id) {
+				throw new Error('Profile ID is missing');
+			}
+
+			const result = await updateProfile(currentProfile.id, {
+				name,
+				line_manager_name: lineManagerName || null,
+				line_manager_email: lineManagerEmail || null
+			});
+
+			if (result.error) {
+				throw new Error(result.error.message);
+			}
+
+			if (result.data) {
+				// Update the app state with new profile data
+				setProfile({
+					id: result.data.user_id,
+					name: result.data.name,
+					is_line_manager: result.data.is_line_manager,
+					preferences: result.data.preferences || {}
+				});
+			}
+
+			onclose();
+		} catch (err: any) {
+			error = err.message || 'Failed to update profile';
+		} finally {
+			loading = false;
+		}
+	}
+</script>
+
+{#if show}
+	<div class="modal modal-open">
+		<div class="modal-box max-w-md">
+			<h3 class="text-lg font-bold mb-4">Complete Your Profile</h3>
+			<p class="text-sm opacity-70 mb-4">
+				Welcome! Please provide your name and optionally your line manager's details.
+			</p>
+
+			<form onsubmit={handleSubmit} class="space-y-4">
+				<!-- Name (required) -->
+				<div class="form-control">
+					<label for="name" class="label">
+						<span class="label-text">Your Name *</span>
+					</label>
+					<input
+						id="name"
+						type="text"
+						bind:value={name}
+						placeholder="Enter your name"
+						required
+						disabled={loading}
+						class="input input-bordered w-full"
+					/>
+				</div>
+
+				<!-- Line Manager Name (optional) -->
+				<div class="form-control">
+					<label for="lineManagerName" class="label">
+						<span class="label-text">Line Manager Name (optional)</span>
+					</label>
+					<input
+						id="lineManagerName"
+						type="text"
+						bind:value={lineManagerName}
+						placeholder="Enter line manager's name"
+						disabled={loading}
+						class="input input-bordered w-full"
+					/>
+				</div>
+
+				<!-- Line Manager Email (optional) -->
+				<div class="form-control">
+					<label for="lineManagerEmail" class="label">
+						<span class="label-text">Line Manager Email (optional)</span>
+					</label>
+					<input
+						id="lineManagerEmail"
+						type="email"
+						bind:value={lineManagerEmail}
+						placeholder="manager@example.com"
+						disabled={loading}
+						class="input input-bordered w-full"
+					/>
+				</div>
+
+				{#if error}
+					<div class="alert alert-error">
+						<span>{error}</span>
+					</div>
+				{/if}
+
+				<div class="modal-action">
+					<button type="submit" class="btn btn-primary" disabled={loading || !name.trim()}>
+						{#if loading}
+							<span class="loading loading-spinner"></span>
+							Saving...
+						{:else}
+							Save Profile
+						{/if}
+					</button>
+				</div>
+			</form>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/ui/ProfileCompletionModal.svelte
+++ b/src/lib/components/ui/ProfileCompletionModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
-	import type { Profile } from '$lib/types/appState';
+	import type { Profile, UserPreferences } from '$lib/types/appState';
 	import { updateProfile } from '$lib/services/database/profiles';
 
 	interface Props {
@@ -45,7 +45,7 @@
 					id: result.data.user_id,
 					name: result.data.name,
 					is_line_manager: result.data.is_line_manager,
-					preferences: result.data.preferences || {}
+					preferences: (result.data.preferences as UserPreferences) || {}
 				});
 			}
 
@@ -61,8 +61,8 @@
 {#if show}
 	<div class="modal modal-open">
 		<div class="modal-box max-w-md">
-			<h3 class="text-lg font-bold mb-4">Complete Your Profile</h3>
-			<p class="text-sm opacity-70 mb-4">
+			<h3 class="mb-4 text-lg font-bold">Complete Your Profile</h3>
+			<p class="mb-4 text-sm opacity-70">
 				Welcome! Please provide your name and optionally your line manager's details.
 			</p>
 
@@ -86,7 +86,7 @@
 				<!-- Line Manager Name (optional) -->
 				<div class="form-control">
 					<label for="lineManagerName" class="label">
-						<span class="label-text">Line Manager Name (optional)</span>
+						<span class="label-text">Line Manager Name</span>
 					</label>
 					<input
 						id="lineManagerName"
@@ -101,7 +101,7 @@
 				<!-- Line Manager Email (optional) -->
 				<div class="form-control">
 					<label for="lineManagerEmail" class="label">
-						<span class="label-text">Line Manager Email (optional)</span>
+						<span class="label-text">Line Manager Email</span>
 					</label>
 					<input
 						id="lineManagerEmail"

--- a/src/lib/components/ui/ProfileSettingsModal.svelte
+++ b/src/lib/components/ui/ProfileSettingsModal.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import type { Profile } from '$lib/types/appState';
+	import { updateProfile, getProfile } from '$lib/services/database/profiles';
+
+	interface Props {
+		show: boolean;
+		onclose: () => void;
+	}
+
+	let { show, onclose }: Props = $props();
+
+	const getProfileContext = getContext<() => Profile>('getProfile');
+	const setProfile = getContext<(profile: Profile) => void>('setProfile');
+
+	const currentProfile = $derived(getProfileContext());
+
+	let name = $state('');
+	let email = $state('');
+	let lineManagerName = $state('');
+	let lineManagerEmail = $state('');
+	let loading = $state(false);
+	let error = $state<string | null>(null);
+	let successMessage = $state<string | null>(null);
+
+	// Load current profile data when modal opens
+	$effect(() => {
+		if (show && currentProfile.id) {
+			// Reload fresh profile data from database
+			getProfile(currentProfile.id).then((result) => {
+				if (result.data) {
+					name = result.data.name || '';
+					email = result.data.email || '';
+					lineManagerName = result.data.line_manager_name || '';
+					lineManagerEmail = result.data.line_manager_email || '';
+				}
+			});
+		}
+	});
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		loading = true;
+		error = null;
+		successMessage = null;
+
+		try {
+			if (!currentProfile.id) {
+				throw new Error('Profile ID is missing');
+			}
+
+			const result = await updateProfile(currentProfile.id, {
+				name,
+				line_manager_name: lineManagerName || null,
+				line_manager_email: lineManagerEmail || null
+			});
+
+			if (result.error) {
+				throw new Error(result.error.message);
+			}
+
+			if (result.data) {
+				// Update the app state with new profile data
+				setProfile({
+					id: result.data.user_id,
+					name: result.data.name,
+					is_line_manager: result.data.is_line_manager,
+					preferences: result.data.preferences || {}
+				});
+			}
+
+			successMessage = 'Profile updated successfully!';
+
+			// Close modal after short delay
+			setTimeout(() => {
+				onclose();
+				successMessage = null;
+			}, 1500);
+		} catch (err: any) {
+			error = err.message || 'Failed to update profile';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function handleCancel() {
+		error = null;
+		successMessage = null;
+		onclose();
+	}
+</script>
+
+{#if show}
+	<div class="modal modal-open">
+		<div class="modal-box modal-box-custom mx-auto">
+			<h3 class="text-lg font-bold mb-4 text-center text-base-content">Profile Settings</h3>
+
+			<form onsubmit={handleSubmit} class="space-y-4">
+				<!-- Name (required) -->
+				<div class="form-control">
+					<label for="settings-name" class="label">
+						<span class="label-text text-base-content">Your Name *</span>
+					</label>
+					<input
+						id="settings-name"
+						type="text"
+						bind:value={name}
+						placeholder="Enter your name"
+						required
+						disabled={loading}
+						class="input input-bordered w-full text-base-content"
+					/>
+				</div>
+
+				<!-- Email (read-only) -->
+				<div class="form-control">
+					<label for="settings-email" class="label">
+						<span class="label-text text-base-content">Email (cannot be changed)</span>
+					</label>
+					<input
+						id="settings-email"
+						type="email"
+						value={email}
+						disabled
+						class="input input-bordered w-full bg-base-200 cursor-not-allowed text-base-content"
+					/>
+				</div>
+
+				<!-- Line Manager Name (optional) -->
+				<div class="form-control">
+					<label for="settings-line-manager-name" class="label">
+						<span class="label-text text-base-content">Line Manager Name (optional)</span>
+					</label>
+					<input
+						id="settings-line-manager-name"
+						type="text"
+						bind:value={lineManagerName}
+						placeholder="Enter line manager's name"
+						disabled={loading}
+						class="input input-bordered w-full text-base-content"
+					/>
+				</div>
+
+				<!-- Line Manager Email (optional) -->
+				<div class="form-control">
+					<label for="settings-line-manager-email" class="label">
+						<span class="label-text text-base-content">Line Manager Email (optional)</span>
+					</label>
+					<input
+						id="settings-line-manager-email"
+						type="email"
+						bind:value={lineManagerEmail}
+						placeholder="manager@example.com"
+						disabled={loading}
+						class="input input-bordered w-full text-base-content"
+					/>
+				</div>
+
+				{#if error}
+					<div class="alert alert-error">
+						<span>{error}</span>
+					</div>
+				{/if}
+
+				{#if successMessage}
+					<div class="alert alert-success">
+						<span>{successMessage}</span>
+					</div>
+				{/if}
+
+				<div class="modal-action">
+					<button
+						type="button"
+						class="btn"
+						onclick={handleCancel}
+						disabled={loading}
+					>
+						Cancel
+					</button>
+					<button
+						type="submit"
+						class="btn btn-primary"
+						disabled={loading || !name.trim()}
+					>
+						{#if loading}
+							<span class="loading loading-spinner"></span>
+							Saving...
+						{:else}
+							Save Changes
+						{/if}
+					</button>
+				</div>
+			</form>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/ui/ProfileSettingsModal.svelte
+++ b/src/lib/components/ui/ProfileSettingsModal.svelte
@@ -65,7 +65,7 @@
 					id: result.data.user_id,
 					name: result.data.name,
 					is_line_manager: result.data.is_line_manager,
-					preferences: result.data.preferences || {}
+					preferences: (result.data.preferences as Profile['preferences']) || {}
 				});
 			}
 

--- a/src/lib/components/ui/UndoButton.svelte
+++ b/src/lib/components/ui/UndoButton.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import Tooltip from './Tooltip.svelte';
+
 	interface Props {
 		canUndo: boolean;
 		onclick: () => void;
@@ -7,12 +9,13 @@
 	let { canUndo, onclick }: Props = $props();
 </script>
 
-<button
-	type="button"
-	{onclick}
-	disabled={!canUndo}
-	class="btn-submit btn-sm"
-	title="Undo last change (Ctrl+Z)"
->
-	Undo
-</button>
+<Tooltip text="Undo last change (Ctrl+Z)" position="top">
+	<button
+		type="button"
+		{onclick}
+		disabled={!canUndo}
+		class="btn-submit btn-sm"
+	>
+		Undo
+	</button>
+</Tooltip>

--- a/src/lib/components/views/Dash.svelte
+++ b/src/lib/components/views/Dash.svelte
@@ -41,38 +41,6 @@
 		setList({ table, category });
 		setViewName('list');
 	};
-
-	// ========== TESTING ONLY - REMOVE WHEN DONE ==========
-	const getTestUsers = getContext<() => Profile[]>('getTestUsers');
-	const setTestUser = getContext<(userId: string, userName: string) => Promise<void>>('setTestUser');
-
-	const sortedTestUsers = $derived(
-		[...(getTestUsers() || [])]
-			.filter(
-				(user): user is Profile & { id: string; name: string } =>
-					user.id !== null && user.name !== null && user.is_line_manager === false
-			)
-			.sort((a, b) => a.id.localeCompare(b.id))
-	);
-
-	let dropdownExpanded = $state(false);
-	let selectedUserId = $state<string | null>(null);
-
-	async function handleUserSelect(userId: string, userName: string) {
-		await setTestUser(userId, userName);
-		selectedUserId = userId;
-		console.log('Test user selected:', userName, userId);
-
-		// Close dropdown after selection
-		dropdownExpanded = false;
-		const dropdown = document.activeElement as HTMLElement;
-		dropdown?.blur();
-	}
-
-	function toggleDropdown() {
-		dropdownExpanded = !dropdownExpanded;
-	}
-	// ======================================================
 </script>
 
 <div id="dash-view" class="view">
@@ -81,41 +49,7 @@
 	<div id="dash-tiles" class="view-content">
 		{#if app.profile.id == null}
 			<div class="dash-grid-1">
-				<DashTile title="No Profile Selected" variant="square" disabled />
-
-				<!-- ========== TESTING ONLY - REMOVE WHEN DONE ========== -->
-				<div class="dropdown mt-4">
-					<button
-						type="button"
-						class="btn btn-primary btn-sm"
-						onclick={toggleDropdown}
-						onkeydown={(e) => (e.key === 'Enter' || e.key === ' ' ? toggleDropdown() : null)}
-						aria-label="Select test user for development"
-						aria-expanded={dropdownExpanded}
-						aria-haspopup="listbox"
-					>
-						Select Test User
-					</button>
-					<ul
-						class="dropdown-content menu bg-base-100 rounded-box text-base-content z-1 w-52 p-2 shadow-sm"
-						role="listbox"
-						aria-label="Available test users"
-					>
-						{#each sortedTestUsers as user (user.id)}
-							<li role="option" aria-selected={selectedUserId === user.id}>
-								<button
-									onclick={() => handleUserSelect(user.id, user.name)}
-									class="text-left"
-									aria-label="Select {user.name} as test user"
-								>
-									<span class="text-xs opacity-60">{user.id.slice(-2)}</span>
-									{user.name}
-								</button>
-							</li>
-						{/each}
-					</ul>
-				</div>
-				<!-- ====================================================== -->
+				<DashTile title="Loading Profile..." loading={true} disabled />
 			</div>
 		{:else}
 			<!-- Actions Section -->

--- a/src/lib/components/views/Dash.svelte
+++ b/src/lib/components/views/Dash.svelte
@@ -8,7 +8,7 @@
 	import { getQuestions } from '$lib/services/database/questions';
 	import { getResources } from '$lib/services/database/resources';
 	import { getUserResponses } from '$lib/services/database/responses';
-	import type { Question } from '$lib/types/tableMain';
+	import type { Question, Response } from '$lib/types/tableMain';
 	import type { AppState, ItemCategory, List, TableName, ViewName, Profile } from '$lib/types/appState';
 	import { makePretty } from '$lib/utils/textTools';
 
@@ -93,10 +93,10 @@
 							{#if questionsResult.data}
 								{#each extractCategories(questionsResult.data) as category}
 									{@const table = 'questions'}
-									{@const categoryQuestions = questionsResult.data.filter(q => q.category === category.raw)}
+									{@const categoryQuestions = questionsResult.data.filter((q: Question) => q.category === category.raw)}
 									{@const total = categoryQuestions.length}
-									{@const answeredQuestionIds = new Set(responsesResult?.data?.map(r => r.question_id) || [])}
-									{@const completed = categoryQuestions.filter(q => answeredQuestionIds.has(q.id)).length}
+									{@const answeredQuestionIds = new Set(responsesResult?.data?.map((r: Response) => r.question_id) || [])}
+									{@const completed = categoryQuestions.filter((q: Question) => answeredQuestionIds.has(q.id)).length}
 									{@const completionText = `${completed}/${total}`}
 									<DashTile
 										title={category.format}

--- a/src/lib/components/views/Dash.svelte
+++ b/src/lib/components/views/Dash.svelte
@@ -96,7 +96,7 @@
 									{@const categoryQuestions = questionsResult.data.filter((q: Question) => q.category === category.raw)}
 									{@const total = categoryQuestions.length}
 									{@const answeredQuestionIds = new Set(responsesResult?.data?.map((r: Response) => r.question_id) || [])}
-									{@const completed = categoryQuestions.filter((q: Question) => answeredQuestionIds.has(q.id)).length}
+									{@const completed = categoryQuestions.filter((q: Question) => q.id && answeredQuestionIds.has(q.id)).length}
 									{@const completionText = `${completed}/${total}`}
 									<DashTile
 										title={category.format}

--- a/src/lib/services/database/types.ts
+++ b/src/lib/services/database/types.ts
@@ -1,40 +1,556 @@
-// Re-export commonly used types
-export type { Database, Tables, TablesInsert, TablesUpdate } from '$lib/types/supabase';
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
 
-// Common response types
-export type DbResult<T> = Promise<{
-	data: T | null;
-	error: Error | null;
-}>;
-
-export type DbResultMany<T> = Promise<{
-	data: T[] | null;
-	error: Error | null;
-}>;
-
-// Common error types
-export class DatabaseError extends Error {
-	constructor(
-		message: string,
-		public code?: string
-	) {
-		super(message);
-		this.name = 'DatabaseError';
-	}
+export type Database = {
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      actions: {
+        Row: {
+          created_at: string | null
+          description: string | null
+          id: string
+          response_id: string | null
+          status: string
+          type: string
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          response_id?: string | null
+          status?: string
+          type: string
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          response_id?: string | null
+          status?: string
+          type?: string
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "actions_response_id_fkey"
+            columns: ["response_id"]
+            isOneToOne: false
+            referencedRelation: "responses"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      line_managers: {
+        Row: {
+          created_at: string | null
+          email: string | null
+          id: string
+          line_manager_id: string
+          organization_id: string
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          email?: string | null
+          id?: string
+          line_manager_id: string
+          organization_id: string
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          email?: string | null
+          id?: string
+          line_manager_id?: string
+          organization_id?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "line_managers_line_manager_id_fkey"
+            columns: ["line_manager_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "line_managers_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      organizations: {
+        Row: {
+          created_at: string | null
+          id: string
+          name: string
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          name: string
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          name?: string
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      profiles: {
+        Row: {
+          email: string | null
+          id: string
+          inserted_at: string | null
+          is_line_manager: boolean | null
+          job_title: string | null
+          line_manager: string | null
+          line_manager_email: string | null
+          line_manager_name: string | null
+          name: string | null
+          preferences: Json
+          pronouns: string[] | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          email?: string | null
+          id?: string
+          inserted_at?: string | null
+          is_line_manager?: boolean | null
+          job_title?: string | null
+          line_manager?: string | null
+          line_manager_email?: string | null
+          line_manager_name?: string | null
+          name?: string | null
+          preferences?: Json
+          pronouns?: string[] | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          email?: string | null
+          id?: string
+          inserted_at?: string | null
+          is_line_manager?: boolean | null
+          job_title?: string | null
+          line_manager?: string | null
+          line_manager_email?: string | null
+          line_manager_name?: string | null
+          name?: string | null
+          preferences?: Json
+          pronouns?: string[] | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profiles_line_manager_fkey"
+            columns: ["line_manager"]
+            isOneToOne: false
+            referencedRelation: "line_managers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      questions: {
+        Row: {
+          category: string
+          id: string
+          order: number
+          preview: string | null
+          question_text: string
+        }
+        Insert: {
+          category: string
+          id?: string
+          order: number
+          preview?: string | null
+          question_text: string
+        }
+        Update: {
+          category?: string
+          id?: string
+          order?: number
+          preview?: string | null
+          question_text?: string
+        }
+        Relationships: []
+      }
+      resources: {
+        Row: {
+          created_at: string | null
+          description: string | null
+          id: string
+          title: string
+          updated_at: string | null
+          url: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          title: string
+          updated_at?: string | null
+          url?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          title?: string
+          updated_at?: string | null
+          url?: string | null
+        }
+        Relationships: []
+      }
+      responses: {
+        Row: {
+          created_at: string | null
+          id: string
+          question_id: string | null
+          response_text: string | null
+          status: string | null
+          updated_at: string | null
+          user_id: string | null
+          visibility: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          question_id?: string | null
+          response_text?: string | null
+          status?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+          visibility?: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          question_id?: string | null
+          response_text?: string | null
+          status?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+          visibility?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "responses_question_id_fkey"
+            columns: ["question_id"]
+            isOneToOne: false
+            referencedRelation: "questions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      responses_backup: {
+        Row: {
+          created_at: string | null
+          id: string | null
+          question_id: string | null
+          response_text: string | null
+          status: string | null
+          updated_at: string | null
+          user_id: string | null
+          version: number | null
+          visibility: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string | null
+          question_id?: string | null
+          response_text?: string | null
+          status?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+          version?: number | null
+          visibility?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string | null
+          question_id?: string | null
+          response_text?: string | null
+          status?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+          version?: number | null
+          visibility?: string | null
+        }
+        Relationships: []
+      }
+      sharing_event_actions: {
+        Row: {
+          action_id: string | null
+          id: string
+          sharing_event_id: string | null
+        }
+        Insert: {
+          action_id?: string | null
+          id?: string
+          sharing_event_id?: string | null
+        }
+        Update: {
+          action_id?: string | null
+          id?: string
+          sharing_event_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "sharing_event_actions_action_id_fkey"
+            columns: ["action_id"]
+            isOneToOne: false
+            referencedRelation: "actions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "sharing_event_actions_sharing_event_id_fkey"
+            columns: ["sharing_event_id"]
+            isOneToOne: false
+            referencedRelation: "sharing_events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      sharing_event_responses: {
+        Row: {
+          id: string
+          response_id: string | null
+          sharing_event_id: string | null
+        }
+        Insert: {
+          id?: string
+          response_id?: string | null
+          sharing_event_id?: string | null
+        }
+        Update: {
+          id?: string
+          response_id?: string | null
+          sharing_event_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "sharing_event_responses_response_id_fkey"
+            columns: ["response_id"]
+            isOneToOne: false
+            referencedRelation: "responses"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "sharing_event_responses_sharing_event_id_fkey"
+            columns: ["sharing_event_id"]
+            isOneToOne: false
+            referencedRelation: "sharing_events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      sharing_events: {
+        Row: {
+          id: string
+          message: string | null
+          recipient_email: string
+          shared_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          id?: string
+          message?: string | null
+          recipient_email: string
+          shared_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          id?: string
+          message?: string | null
+          recipient_email?: string
+          shared_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
 }
 
-// Common query options
-export interface QueryOptions {
-	limit?: number;
-	offset?: number;
-	orderBy?: {
-		column: string;
-		ascending?: boolean;
-	};
-}
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-// Common filter options
-export interface FilterOptions {
-	status?: string;
-	visibility?: 'public' | 'private';
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
 }
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {},
+  },
+} as const
+

--- a/src/lib/services/database/types.ts
+++ b/src/lib/services/database/types.ts
@@ -554,3 +554,27 @@ export const Constants = {
   },
 } as const
 
+// Database service layer types
+export type DbResult<T> = Promise<{
+	data: T | null;
+	error: any;
+}>;
+
+export type DbResultMany<T> = Promise<{
+	data: T[] | null;
+	error: any;
+}>;
+
+export interface QueryOptions {
+	orderBy?: {
+		column: string;
+		ascending?: boolean;
+	};
+	limit?: number;
+	offset?: number;
+}
+
+export interface FilterOptions {
+	visibility?: 'public' | 'private';
+	status?: string;
+}

--- a/src/lib/services/supabaseClient.ts
+++ b/src/lib/services/supabaseClient.ts
@@ -1,7 +1,7 @@
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public';
-import { createClient } from '@supabase/supabase-js';
+import { createBrowserClient } from '@supabase/ssr';
 
 const supabaseUrl = PUBLIC_SUPABASE_URL;
 const supabaseKey = PUBLIC_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseKey);
+export const supabase = createBrowserClient(supabaseUrl, supabaseKey);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -29,10 +29,6 @@
 	import Header from '$lib/components/layouts/Header.svelte';
 	import Footer from '$lib/components/layouts/Footer.svelte';
 
-	// ========== TESTING ONLY - REMOVE WHEN DONE ==========
-	import { getAllProfiles, getProfile } from '$lib/services/database/profiles';
-	import { onMount } from 'svelte';
-	// ======================================================
 
 	// Dev Mode
 	let devMode = $state<boolean>(false);
@@ -41,10 +37,6 @@
 	setContext('setDevMode', () => {
 		devMode = !devMode;
 	});
-
-	// ========== TESTING ONLY - REMOVE WHEN DONE ==========
-	let testUsers = $state<Profile[]>([]);
-	// ======================================================
 
 	// =1 App State
 	let appState = $state<AppState>({
@@ -157,56 +149,6 @@
 	setContext('setViewName', (newView: ViewName) => {
 		appState.view.name = newView;
 	});
-
-	// ========== TESTING ONLY - REMOVE WHEN DONE ==========
-	// Add context for test users
-	setContext('getTestUsers', () => testUsers);
-	setContext('setTestUser', async (userId: string, userName: string) => {
-		// Set basic info immediately for UI responsiveness
-		appState.profile.id = userId;
-		appState.profile.name = userName;
-
-		// Load full profile data including preferences
-		try {
-			const result = await getProfile(userId);
-			if (result.data) {
-				appState.profile = {
-					id: result.data.user_id,
-					name: result.data.name,
-					is_line_manager: result.data.is_line_manager,
-					preferences: (result.data.preferences as UserPreferences) || {}
-				};
-			}
-		} catch (error) {
-			console.error('Failed to load profile preferences:', error);
-		}
-	});
-
-	// Fetch all profiles for testing dropdown
-	onMount(() => {
-		let cancelled = false;
-
-		(async () => {
-			const result = await getAllProfiles();
-			if (!cancelled) {
-				if (result.data) {
-					testUsers = result.data.map(user => ({
-						...user,
-						id: user.user_id,
-						preferences: (user.preferences as UserPreferences) || {}
-					}));
-					console.log('Test users loaded:', testUsers.length);
-				} else if (result.error) {
-					console.warn('Could not load test users for development:', result.error.message);
-				}
-			}
-		})();
-
-		return () => {
-			cancelled = true;
-		};
-	});
-	// ======================================================
 
 	// =1 Child Props
 	let { children } = $props();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { supabase } from '$lib/services/supabaseClient';
+	import { Icon, Envelope } from 'svelte-hero-icons';
 
 	let email = $state('');
 	let loading = $state(false);
@@ -34,13 +35,15 @@
 	}
 </script>
 
-<div class="flex min-h-screen items-center justify-center bg-base-200 p-4">
+<div class="flex min-h-screen items-start justify-center bg-base-200 p-4 pt-20">
 	<div class="card w-full max-w-md bg-base-100 shadow-xl">
 		<div class="card-body">
 			<h2 class="card-title text-2xl font-bold">LIFT Digital Workplace Passport</h2>
 
 			{#if !sent}
-				<p class="text-sm opacity-70">Sign in with your email to access your workplace passport</p>
+				<p class="text-sm opacity-70">
+					Enter your email to sign in or create a new account. We'll send you a magic link.
+				</p>
 
 				<form onsubmit={handleSubmit} class="mt-4 space-y-4">
 					<div class="form-control">
@@ -70,6 +73,7 @@
 							<span class="loading loading-spinner"></span>
 							Sending magic link...
 						{:else}
+							<Icon src={Envelope} solid class="h-5 w-5" />
 							Send magic link
 						{/if}
 					</button>
@@ -92,7 +96,7 @@
 					<div>
 						<h3 class="font-bold">Check your email!</h3>
 						<div class="text-xs">
-							We've sent a magic link to <strong>{email}</strong>. Click the link to sign in.
+							We've sent a magic link to <strong>{email}</strong>. Click the link to continue.
 						</div>
 					</div>
 				</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,26 +1,110 @@
 <script lang="ts">
-	import { getContext } from 'svelte';
-	import type { ViewName } from '$lib/types/appState';
-	import Dash from '$lib/components/views/Dash.svelte';
-	import Detail from '$lib/components/views/Detail.svelte';
-	import List from '$lib/components/views/List.svelte';
-	import Email from '$lib/components/views/Email.svelte';
+	import { supabase } from '$lib/services/supabaseClient';
 
-	const getViewName = getContext<() => ViewName>('getViewName');
+	let email = $state('');
+	let loading = $state(false);
+	let error = $state<string | null>(null);
+	let sent = $state(false);
 
-	let view = $derived(getViewName());
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		loading = true;
+		error = null;
+
+		try {
+			const { error: authError } = await supabase.auth.signInWithOtp({
+				email: email.trim().toLowerCase(),
+				options: {
+					emailRedirectTo: `${window.location.origin}/auth/callback`
+				}
+			});
+
+			if (authError) throw authError;
+
+			sent = true;
+		} catch (err: any) {
+			error = err.message || 'Failed to send magic link';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function handleDoubleClick() {
+		email = 'alex.chen@example.com';
+	}
 </script>
 
-<div class="h-full w-full overflow-y-auto">
-	{#if view === 'dash'}
-		<Dash />
-	{:else if view === 'list'}
-		<List />
-	{:else if view === 'detail'}
-		<Detail />
-	{:else if view === 'email'}
-		<Email />
-	{:else}
-		<div class="p-4">No view selected</div>
-	{/if}
+<div class="flex min-h-screen items-center justify-center bg-base-200 p-4">
+	<div class="card w-full max-w-md bg-base-100 shadow-xl">
+		<div class="card-body">
+			<h2 class="card-title text-2xl font-bold">LIFT Digital Workplace Passport</h2>
+
+			{#if !sent}
+				<p class="text-sm opacity-70">Sign in with your email to access your workplace passport</p>
+
+				<form onsubmit={handleSubmit} class="mt-4 space-y-4">
+					<div class="form-control">
+						<label for="email" class="label">
+							<span class="label-text">Email address</span>
+						</label>
+						<input
+							id="email"
+							type="email"
+							bind:value={email}
+							placeholder="you@example.com"
+							required
+							disabled={loading}
+							class="input input-bordered w-full"
+							ondblclick={handleDoubleClick}
+						/>
+					</div>
+
+					{#if error}
+						<div class="alert alert-error">
+							<span>{error}</span>
+						</div>
+					{/if}
+
+					<button type="submit" class="btn btn-primary w-full" disabled={loading}>
+						{#if loading}
+							<span class="loading loading-spinner"></span>
+							Sending magic link...
+						{:else}
+							Send magic link
+						{/if}
+					</button>
+				</form>
+			{:else}
+				<div class="alert alert-success">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						class="h-6 w-6 shrink-0 stroke-current"
+						fill="none"
+						viewBox="0 0 24 24"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+						/>
+					</svg>
+					<div>
+						<h3 class="font-bold">Check your email!</h3>
+						<div class="text-xs">
+							We've sent a magic link to <strong>{email}</strong>. Click the link to sign in.
+						</div>
+					</div>
+				</div>
+
+				<p class="mt-4 text-sm opacity-70">
+					Didn't receive the email? Check your spam folder or try again.
+				</p>
+
+				<button onclick={() => (sent = false)} class="btn btn-ghost btn-sm mt-2">
+					Try different email
+				</button>
+			{/if}
+		</div>
+	</div>
 </div>

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -1,0 +1,38 @@
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
+	const token_hash = url.searchParams.get('token_hash');
+	const type = url.searchParams.get('type');
+	const code = url.searchParams.get('code');
+
+	console.log('🔐 Auth callback triggered');
+	console.log('📝 URL params:', { token_hash: !!token_hash, type, code: !!code });
+
+	// Handle PKCE flow (code)
+	if (code) {
+		const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+		console.log('🔄 PKCE exchange result:', { session: !!data.session, error });
+
+		if (error) {
+			console.error('❌ PKCE exchange error:', error);
+			throw redirect(303, '/dashboard#error=' + error.message);
+		}
+	}
+	// Handle magic link flow (token_hash)
+	else if (token_hash && type) {
+		const { data, error } = await supabase.auth.verifyOtp({
+			token_hash,
+			type: type as any
+		});
+		console.log('🔄 OTP verify result:', { session: !!data.session, error });
+
+		if (error) {
+			console.error('❌ OTP verify error:', error);
+			throw redirect(303, `/dashboard#error=access_denied&error_code=${error.code || 'unknown'}&error_description=${encodeURIComponent(error.message)}`);
+		}
+	}
+
+	console.log('✅ Redirecting to dashboard');
+	throw redirect(303, '/dashboard');
+};

--- a/src/routes/dashboard/+layout.server.ts
+++ b/src/routes/dashboard/+layout.server.ts
@@ -26,7 +26,7 @@ export const load: LayoutServerLoad = async ({ locals: { getSession } }) => {
 				id: result.data.user_id,
 				name: result.data.name,
 				is_line_manager: result.data.is_line_manager,
-				preferences: result.data.preferences || {}
+				preferences: (result.data.preferences as import('$lib/types/appState').UserPreferences) || {}
 			};
 			console.log('✅ Profile loaded:', profile);
 		} else if (result.error) {

--- a/src/routes/dashboard/+layout.server.ts
+++ b/src/routes/dashboard/+layout.server.ts
@@ -1,0 +1,38 @@
+import { redirect } from '@sveltejs/kit';
+import { dev } from '$app/environment';
+import { getProfile } from '$lib/services/database/profiles';
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ locals: { getSession } }) => {
+	const session = await getSession();
+
+	// In production, require authentication
+	// In dev mode, allow access for testing with test users
+	if (!session && !dev) {
+		throw redirect(303, '/');
+	}
+
+	// Load user profile if authenticated
+	let profile = null;
+	if (session?.user?.id) {
+		console.log('🔍 Looking for profile with user_id:', session.user.id);
+		console.log('📧 User email:', session.user.email);
+
+		const result = await getProfile(session.user.id);
+		console.log('📊 Profile query result:', result);
+
+		if (result.data) {
+			profile = {
+				id: result.data.user_id,
+				name: result.data.name,
+				is_line_manager: result.data.is_line_manager,
+				preferences: result.data.preferences || {}
+			};
+			console.log('✅ Profile loaded:', profile);
+		} else if (result.error) {
+			console.error('❌ Profile error:', result.error);
+		}
+	}
+
+	return { session, profile };
+};

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { getContext, onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import type { Profile } from '$lib/types/appState';
+	import ProfileCompletionModal from '$lib/components/ui/ProfileCompletionModal.svelte';
+
+	let { data, children } = $props();
+
+	const setProfile = getContext<(profile: Profile) => void>('setProfile');
+	const getProfile = getContext<() => Profile>('getProfile');
+
+	let authError = $state<{ code: string; description: string } | null>(null);
+	let showProfileModal = $state(false);
+
+	// Check for auth errors in URL hash
+	onMount(() => {
+		console.log('🔧 Dashboard layout mounted');
+		console.log('📦 Data from server:', data);
+
+		const hash = window.location.hash.substring(1);
+		const params = new URLSearchParams(hash);
+
+		if (params.get('error')) {
+			console.log('❌ Auth error found in URL hash');
+			authError = {
+				code: params.get('error_code') || params.get('error') || 'unknown',
+				description: params.get('error_description') || 'Authentication failed'
+			};
+			// Clear the hash from URL
+			window.history.replaceState(null, '', window.location.pathname);
+			return;
+		}
+
+		// Set profile from server data if no error
+		if (data.profile) {
+			console.log('✅ Setting profile from server data:', data.profile);
+			setProfile(data.profile);
+
+			// Check if profile needs completion (name is empty or whitespace)
+			if (!data.profile.name || data.profile.name.trim() === '') {
+				showProfileModal = true;
+			}
+		} else {
+			console.warn('⚠️ No profile data from server');
+			console.log('Session:', data.session);
+		}
+	});
+
+	function handleRetryLogin() {
+		goto('/');
+	}
+
+	function handleCloseProfileModal() {
+		showProfileModal = false;
+	}
+
+	const currentProfile = $derived(getProfile());
+</script>
+
+{#if authError}
+	<div class="flex items-center justify-center h-full p-4">
+		<div class="card bg-base-100 shadow-xl max-w-md w-full">
+			<div class="card-body">
+				<h2 class="card-title text-error">Authentication Error</h2>
+				<p class="text-base-content/70">
+					{#if authError.code === 'otp_expired'}
+						Your magic link has expired. Magic links are only valid for 1 hour.
+					{:else if authError.code === 'access_denied'}
+						Access was denied. The link may be invalid or has already been used.
+					{:else}
+						{authError.description.replace(/\+/g, ' ')}
+					{/if}
+				</p>
+				<div class="card-actions justify-end mt-4">
+					<button class="btn btn-primary" onclick={handleRetryLogin}>
+						Return to Login
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
+{:else}
+	{@render children()}
+	<ProfileCompletionModal
+		show={showProfileModal}
+		onclose={handleCloseProfileModal}
+		currentProfile={currentProfile}
+	/>
+{/if}

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import type { ViewName } from '$lib/types/appState';
+	import Dash from '$lib/components/views/Dash.svelte';
+	import Detail from '$lib/components/views/Detail.svelte';
+	import List from '$lib/components/views/List.svelte';
+	import Email from '$lib/components/views/Email.svelte';
+
+	const getViewName = getContext<() => ViewName>('getViewName');
+
+	let view = $derived(getViewName());
+</script>
+
+<div class="h-full w-full overflow-y-auto">
+	{#if view === 'dash'}
+		<Dash />
+	{:else if view === 'list'}
+		<List />
+	{:else if view === 'detail'}
+		<Detail />
+	{:else if view === 'email'}
+		<Email />
+	{:else}
+		<div class="p-4">No view selected</div>
+	{/if}
+</div>

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,7 +1,6 @@
 # Supabase
 .branches
 .temp
-config.toml
 .env
 
 # dotenvx

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,171 @@
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "Round02"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` is always included.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request. `public` is always included.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 15
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+[storage.image_transformation]
+enabled = true
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:5173"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["http://127.0.0.1:5173/auth/callback"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+
+# Custom email template for magic link
+[auth.email.template.magic_link]
+subject = "Sign in to LIFT Digital Workplace Passport"
+content_path = "./supabase/templates/magic_link.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = true
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }} ."
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+
+[analytics]
+enabled = false
+port = 54327
+vector_port = 54328
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/supabase/data/test_data_source.json
+++ b/supabase/data/test_data_source.json
@@ -65,7 +65,9 @@
       ],
       "job_title": "Software Developer",
       "is_line_manager": false,
-      "line_manager": "440e8400-e29b-41d4-a716-446655440001"
+      "line_manager": "440e8400-e29b-41d4-a716-446655440001",
+      "line_manager_name": "Sarah Wilson",
+      "line_manager_email": "sarah.wilson@techcorp.com"
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440002",
@@ -78,7 +80,9 @@
       ],
       "job_title": "UX Designer",
       "is_line_manager": false,
-      "line_manager": "440e8400-e29b-41d4-a716-446655440002"
+      "line_manager": "440e8400-e29b-41d4-a716-446655440002",
+      "line_manager_name": "Mike Johnson",
+      "line_manager_email": "mike.johnson@creative.com"
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440003",
@@ -91,7 +95,9 @@
       ],
       "job_title": "Data Analyst",
       "is_line_manager": false,
-      "line_manager": "440e8400-e29b-41d4-a716-446655440003"
+      "line_manager": "440e8400-e29b-41d4-a716-446655440003",
+      "line_manager_name": "Lisa Brown",
+      "line_manager_email": "lisa.brown@dataflow.com"
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440004",
@@ -104,7 +110,9 @@
       ],
       "job_title": "Product Manager",
       "is_line_manager": false,
-      "line_manager": "440e8400-e29b-41d4-a716-446655440004"
+      "line_manager": "440e8400-e29b-41d4-a716-446655440004",
+      "line_manager_name": "David Kim",
+      "line_manager_email": "david.kim@innovatecorp.com"
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440005",
@@ -117,7 +125,9 @@
       ],
       "job_title": "Marketing Specialist",
       "is_line_manager": false,
-      "line_manager": "440e8400-e29b-41d4-a716-446655440005"
+      "line_manager": "440e8400-e29b-41d4-a716-446655440005",
+      "line_manager_name": "Emma Rodriguez",
+      "line_manager_email": "emma.rodriguez@brandworks.com"
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440010",
@@ -130,7 +140,9 @@
       ],
       "job_title": "Engineering Manager",
       "is_line_manager": true,
-      "line_manager": null
+      "line_manager": null,
+      "line_manager_name": null,
+      "line_manager_email": null
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440011",
@@ -143,7 +155,9 @@
       ],
       "job_title": "Design Director",
       "is_line_manager": true,
-      "line_manager": null
+      "line_manager": null,
+      "line_manager_name": null,
+      "line_manager_email": null
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440012",
@@ -156,7 +170,9 @@
       ],
       "job_title": "Analytics Lead",
       "is_line_manager": true,
-      "line_manager": null
+      "line_manager": null,
+      "line_manager_name": null,
+      "line_manager_email": null
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440013",
@@ -169,7 +185,9 @@
       ],
       "job_title": "Product Director",
       "is_line_manager": true,
-      "line_manager": null
+      "line_manager": null,
+      "line_manager_name": null,
+      "line_manager_email": null
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440014",
@@ -182,7 +200,9 @@
       ],
       "job_title": "Marketing Director",
       "is_line_manager": true,
-      "line_manager": null
+      "line_manager": null,
+      "line_manager_name": null,
+      "line_manager_email": null
     }
   ],
   "responses": [

--- a/supabase/generated/test_fake_data.sql
+++ b/supabase/generated/test_fake_data.sql
@@ -3,14 +3,12 @@
 -- DO NOT EDIT MANUALLY - run scripts/generate-test-data.sh to regenerate
 
 -- ===========================================
--- ORGANIZATIONS
+-- ORGANIZATIONS (skipped - using simplified line manager fields instead)
 -- ===========================================
+-- We now use line_manager_name and line_manager_email fields directly on profiles
+-- The old organizations and line_managers tables are kept for backward compatibility
+-- but not populated in test data
 
-INSERT INTO organizations (id, name) VALUES ('990e8400-e29b-41d4-a716-446655440001'::uuid, 'TechCorp Ltd');
-INSERT INTO organizations (id, name) VALUES ('990e8400-e29b-41d4-a716-446655440002'::uuid, 'Creative Agency');
-INSERT INTO organizations (id, name) VALUES ('990e8400-e29b-41d4-a716-446655440003'::uuid, 'DataFlow Inc');
-INSERT INTO organizations (id, name) VALUES ('990e8400-e29b-41d4-a716-446655440004'::uuid, 'InnovateCorp');
-INSERT INTO organizations (id, name) VALUES ('990e8400-e29b-41d4-a716-446655440005'::uuid, 'BrandWorks');
 
 -- ===========================================
 -- AUTH USERS (for local testing only)
@@ -308,40 +306,97 @@ INSERT INTO auth.users (
 );
 
 -- ===========================================
--- PROFILES (step 1: without line_manager FK)
+-- PROFILES (auto-created by trigger, update with additional fields)
 -- ===========================================
 
-INSERT INTO profiles (id, user_id, name, pronouns, job_title, is_line_manager) VALUES
-  ('550e8400-e29b-41d4-a716-446655440001'::uuid, '550e8400-e29b-41d4-a716-446655440001'::uuid, 'Alex Chen', ARRAY['they', 'them', 'theirs'], 'Software Developer', false),
-  ('550e8400-e29b-41d4-a716-446655440002'::uuid, '550e8400-e29b-41d4-a716-446655440002'::uuid, 'Jordan Taylor', ARRAY['she', 'her', 'hers'], 'UX Designer', false),
-  ('550e8400-e29b-41d4-a716-446655440003'::uuid, '550e8400-e29b-41d4-a716-446655440003'::uuid, 'Sam Mitchell', ARRAY['he', 'him', 'his'], 'Data Analyst', false),
-  ('550e8400-e29b-41d4-a716-446655440004'::uuid, '550e8400-e29b-41d4-a716-446655440004'::uuid, 'Riley Johnson', ARRAY['she', 'her', 'hers'], 'Product Manager', false),
-  ('550e8400-e29b-41d4-a716-446655440005'::uuid, '550e8400-e29b-41d4-a716-446655440005'::uuid, 'Casey Williams', ARRAY['he', 'him', 'his'], 'Marketing Specialist', false),
-  ('550e8400-e29b-41d4-a716-446655440010'::uuid, '550e8400-e29b-41d4-a716-446655440010'::uuid, 'Sarah Wilson', ARRAY['she', 'her', 'hers'], 'Engineering Manager', true),
-  ('550e8400-e29b-41d4-a716-446655440011'::uuid, '550e8400-e29b-41d4-a716-446655440011'::uuid, 'Mike Johnson', ARRAY['he', 'him', 'his'], 'Design Director', true),
-  ('550e8400-e29b-41d4-a716-446655440012'::uuid, '550e8400-e29b-41d4-a716-446655440012'::uuid, 'Lisa Brown', ARRAY['she', 'her', 'hers'], 'Analytics Lead', true),
-  ('550e8400-e29b-41d4-a716-446655440013'::uuid, '550e8400-e29b-41d4-a716-446655440013'::uuid, 'David Kim', ARRAY['he', 'him', 'his'], 'Product Director', true),
-  ('550e8400-e29b-41d4-a716-446655440014'::uuid, '550e8400-e29b-41d4-a716-446655440014'::uuid, 'Emma Rodriguez', ARRAY['she', 'her', 'hers'], 'Marketing Director', true);
+UPDATE profiles SET
+  name = 'Alex Chen',
+  pronouns = ARRAY['they', 'them', 'theirs'],
+  job_title = 'Software Developer',
+  is_line_manager = false,
+  line_manager_name = 'Sarah Wilson',
+  line_manager_email = 'sarah.wilson@techcorp.com'
+WHERE user_id = '550e8400-e29b-41d4-a716-446655440001'::uuid;
+UPDATE profiles SET
+  name = 'Jordan Taylor',
+  pronouns = ARRAY['she', 'her', 'hers'],
+  job_title = 'UX Designer',
+  is_line_manager = false,
+  line_manager_name = 'Mike Johnson',
+  line_manager_email = 'mike.johnson@creative.com'
+WHERE user_id = '550e8400-e29b-41d4-a716-446655440002'::uuid;
+UPDATE profiles SET
+  name = 'Sam Mitchell',
+  pronouns = ARRAY['he', 'him', 'his'],
+  job_title = 'Data Analyst',
+  is_line_manager = false,
+  line_manager_name = 'Lisa Brown',
+  line_manager_email = 'lisa.brown@dataflow.com'
+WHERE user_id = '550e8400-e29b-41d4-a716-446655440003'::uuid;
+UPDATE profiles SET
+  name = 'Riley Johnson',
+  pronouns = ARRAY['she', 'her', 'hers'],
+  job_title = 'Product Manager',
+  is_line_manager = false,
+  line_manager_name = 'David Kim',
+  line_manager_email = 'david.kim@innovatecorp.com'
+WHERE user_id = '550e8400-e29b-41d4-a716-446655440004'::uuid;
+UPDATE profiles SET
+  name = 'Casey Williams',
+  pronouns = ARRAY['he', 'him', 'his'],
+  job_title = 'Marketing Specialist',
+  is_line_manager = false,
+  line_manager_name = 'Emma Rodriguez',
+  line_manager_email = 'emma.rodriguez@brandworks.com'
+WHERE user_id = '550e8400-e29b-41d4-a716-446655440005'::uuid;
+UPDATE profiles SET
+  name = 'Sarah Wilson',
+  pronouns = ARRAY['she', 'her', 'hers'],
+  job_title = 'Engineering Manager',
+  is_line_manager = true,
+  line_manager_name = NULL,
+  line_manager_email = NULL
+WHERE user_id = '550e8400-e29b-41d4-a716-446655440010'::uuid;
+UPDATE profiles SET
+  name = 'Mike Johnson',
+  pronouns = ARRAY['he', 'him', 'his'],
+  job_title = 'Design Director',
+  is_line_manager = true,
+  line_manager_name = NULL,
+  line_manager_email = NULL
+WHERE user_id = '550e8400-e29b-41d4-a716-446655440011'::uuid;
+UPDATE profiles SET
+  name = 'Lisa Brown',
+  pronouns = ARRAY['she', 'her', 'hers'],
+  job_title = 'Analytics Lead',
+  is_line_manager = true,
+  line_manager_name = NULL,
+  line_manager_email = NULL
+WHERE user_id = '550e8400-e29b-41d4-a716-446655440012'::uuid;
+UPDATE profiles SET
+  name = 'David Kim',
+  pronouns = ARRAY['he', 'him', 'his'],
+  job_title = 'Product Director',
+  is_line_manager = true,
+  line_manager_name = NULL,
+  line_manager_email = NULL
+WHERE user_id = '550e8400-e29b-41d4-a716-446655440013'::uuid;
+UPDATE profiles SET
+  name = 'Emma Rodriguez',
+  pronouns = ARRAY['she', 'her', 'hers'],
+  job_title = 'Marketing Director',
+  is_line_manager = true,
+  line_manager_name = NULL,
+  line_manager_email = NULL
+WHERE user_id = '550e8400-e29b-41d4-a716-446655440014'::uuid;
 
 -- ===========================================
--- LINE MANAGERS
+-- LINE MANAGERS (skipped - using simplified approach)
 -- ===========================================
+-- We now store line manager info directly on profiles via:
+-- - line_manager_name (TEXT)
+-- - line_manager_email (TEXT)
 
-INSERT INTO line_managers (id, line_manager_id, organization_id, email) VALUES ('440e8400-e29b-41d4-a716-446655440001'::uuid, '550e8400-e29b-41d4-a716-446655440010'::uuid, '990e8400-e29b-41d4-a716-446655440001'::uuid, 'sarah.wilson@techcorp.com');
-INSERT INTO line_managers (id, line_manager_id, organization_id, email) VALUES ('440e8400-e29b-41d4-a716-446655440002'::uuid, '550e8400-e29b-41d4-a716-446655440011'::uuid, '990e8400-e29b-41d4-a716-446655440002'::uuid, 'mike.johnson@creative.com');
-INSERT INTO line_managers (id, line_manager_id, organization_id, email) VALUES ('440e8400-e29b-41d4-a716-446655440003'::uuid, '550e8400-e29b-41d4-a716-446655440012'::uuid, '990e8400-e29b-41d4-a716-446655440003'::uuid, 'lisa.brown@dataflow.com');
-INSERT INTO line_managers (id, line_manager_id, organization_id, email) VALUES ('440e8400-e29b-41d4-a716-446655440004'::uuid, '550e8400-e29b-41d4-a716-446655440013'::uuid, '990e8400-e29b-41d4-a716-446655440004'::uuid, 'david.kim@innovatecorp.com');
-INSERT INTO line_managers (id, line_manager_id, organization_id, email) VALUES ('440e8400-e29b-41d4-a716-446655440005'::uuid, '550e8400-e29b-41d4-a716-446655440014'::uuid, '990e8400-e29b-41d4-a716-446655440005'::uuid, 'emma.rodriguez@brandworks.com');
-
--- ===========================================
--- PROFILES (step 2: update line_manager FK)
--- ===========================================
-
-UPDATE profiles SET line_manager = '440e8400-e29b-41d4-a716-446655440001'::uuid WHERE id = '550e8400-e29b-41d4-a716-446655440001'::uuid;
-UPDATE profiles SET line_manager = '440e8400-e29b-41d4-a716-446655440002'::uuid WHERE id = '550e8400-e29b-41d4-a716-446655440002'::uuid;
-UPDATE profiles SET line_manager = '440e8400-e29b-41d4-a716-446655440003'::uuid WHERE id = '550e8400-e29b-41d4-a716-446655440003'::uuid;
-UPDATE profiles SET line_manager = '440e8400-e29b-41d4-a716-446655440004'::uuid WHERE id = '550e8400-e29b-41d4-a716-446655440004'::uuid;
-UPDATE profiles SET line_manager = '440e8400-e29b-41d4-a716-446655440005'::uuid WHERE id = '550e8400-e29b-41d4-a716-446655440005'::uuid;
 
 -- ===========================================
 -- RESPONSES

--- a/supabase/migrations/20251021100148_add_auth_fields_to_profiles.sql
+++ b/supabase/migrations/20251021100148_add_auth_fields_to_profiles.sql
@@ -1,0 +1,115 @@
+-- Add email and line manager fields to profiles
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS email TEXT UNIQUE,
+  ADD COLUMN IF NOT EXISTS line_manager_name TEXT,
+  ADD COLUMN IF NOT EXISTS line_manager_email TEXT;
+
+-- Add unique constraint on user_id (required for ON CONFLICT in trigger)
+ALTER TABLE profiles
+  ADD CONSTRAINT profiles_user_id_unique UNIQUE (user_id);
+
+-- Create index for faster lookups (may already exist)
+CREATE INDEX IF NOT EXISTS idx_profiles_user_id ON profiles(user_id);
+
+-- Auto-create profile when user signs up
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.profiles (user_id, email, name, inserted_at, updated_at)
+  VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'name', ''),
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_new_user();
+
+-- Sync email when auth.users email changes
+CREATE OR REPLACE FUNCTION sync_profile_email()
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE profiles
+  SET email = NEW.email, updated_at = NOW()
+  WHERE user_id = NEW.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS on_auth_user_email_updated ON auth.users;
+CREATE TRIGGER on_auth_user_email_updated
+  AFTER UPDATE OF email ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION sync_profile_email();
+
+-- Enable RLS on all tables if not already enabled
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE responses ENABLE ROW LEVEL SECURITY;
+ALTER TABLE actions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sharing_events ENABLE ROW LEVEL SECURITY;
+
+-- Drop existing policies if they exist (to avoid conflicts)
+DROP POLICY IF EXISTS "Users can view own profile" ON profiles;
+DROP POLICY IF EXISTS "Users can update own profile" ON profiles;
+DROP POLICY IF EXISTS "Users can insert own profile" ON profiles;
+DROP POLICY IF EXISTS "Users can manage own responses" ON responses;
+DROP POLICY IF EXISTS "Users can manage own actions" ON actions;
+DROP POLICY IF EXISTS "Users can manage own sharing events" ON sharing_events;
+DROP POLICY IF EXISTS "Service role full access profiles" ON profiles;
+DROP POLICY IF EXISTS "Service role full access responses" ON responses;
+DROP POLICY IF EXISTS "Service role full access actions" ON actions;
+DROP POLICY IF EXISTS "Service role full access sharing_events" ON sharing_events;
+
+-- Profiles: Users can read/update their own
+CREATE POLICY "Users can view own profile"
+  ON profiles FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own profile"
+  ON profiles FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own profile"
+  ON profiles FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- Responses: Users can CRUD their own
+CREATE POLICY "Users can manage own responses"
+  ON responses FOR ALL
+  USING (auth.uid() = user_id);
+
+-- Actions: Users can CRUD their own
+CREATE POLICY "Users can manage own actions"
+  ON actions FOR ALL
+  USING (auth.uid() = user_id);
+
+-- Sharing events: Users can manage their own
+CREATE POLICY "Users can manage own sharing events"
+  ON sharing_events FOR ALL
+  USING (auth.uid() = user_id);
+
+-- Service role has full access (for migrations/admin)
+CREATE POLICY "Service role full access profiles"
+  ON profiles FOR ALL
+  USING (auth.jwt() ->> 'role' = 'service_role');
+
+CREATE POLICY "Service role full access responses"
+  ON responses FOR ALL
+  USING (auth.jwt() ->> 'role' = 'service_role');
+
+CREATE POLICY "Service role full access actions"
+  ON actions FOR ALL
+  USING (auth.jwt() ->> 'role' = 'service_role');
+
+CREATE POLICY "Service role full access sharing_events"
+  ON sharing_events FOR ALL
+  USING (auth.jwt() ->> 'role' = 'service_role');

--- a/supabase/migrations/20251021115933_fix_rls_policies_for_insert.sql
+++ b/supabase/migrations/20251021115933_fix_rls_policies_for_insert.sql
@@ -1,0 +1,63 @@
+-- Fix RLS policies to support INSERT operations
+-- The previous policies used USING clause for ALL operations,
+-- but INSERT requires WITH CHECK clause instead
+
+-- Drop old policies
+DROP POLICY IF EXISTS "Users can manage own responses" ON responses;
+DROP POLICY IF EXISTS "Users can manage own actions" ON actions;
+DROP POLICY IF EXISTS "Users can manage own sharing events" ON sharing_events;
+
+-- Recreate policies with proper INSERT support
+-- Responses: Users can read/update/delete their own, and insert with their user_id
+CREATE POLICY "Users can select own responses"
+  ON responses FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own responses"
+  ON responses FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own responses"
+  ON responses FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own responses"
+  ON responses FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Actions: Users can read/update/delete their own, and insert with their user_id
+CREATE POLICY "Users can select own actions"
+  ON actions FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own actions"
+  ON actions FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own actions"
+  ON actions FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own actions"
+  ON actions FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Sharing events: Users can read/update/delete their own, and insert with their user_id
+CREATE POLICY "Users can select own sharing events"
+  ON sharing_events FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own sharing events"
+  ON sharing_events FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own sharing events"
+  ON sharing_events FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own sharing events"
+  ON sharing_events FOR DELETE
+  USING (auth.uid() = user_id);

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -1,153 +1,134 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LIFT - Sign In to Workwise</title>
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-      line-height: 1.6;
-      color: #1f2937;
-      background-color: #f3f4f6;
-      margin: 0;
-      padding: 20px;
-    }
-    .email-container {
-      max-width: 600px;
-      margin: 0 auto;
-      background-color: #ffffff;
-      border-radius: 8px;
-      overflow: hidden;
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    }
-    .email-header {
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      padding: 40px 30px;
-      text-align: center;
-    }
-    .logo {
-      font-size: 32px;
-      font-weight: bold;
-      color: white;
-      margin: 0 0 10px 0;
-      letter-spacing: 2px;
-    }
-    .subtitle {
-      color: rgba(255, 255, 255, 0.9);
-      font-size: 16px;
-      margin: 0;
-    }
-    .email-body {
-      padding: 40px 30px;
-    }
-    .greeting {
-      font-size: 18px;
-      color: #1f2937;
-      margin-bottom: 20px;
-    }
-    .message {
-      font-size: 16px;
-      color: #4b5563;
-      margin-bottom: 30px;
-      line-height: 1.6;
-    }
-    .button-container {
-      text-align: center;
-      margin: 35px 0;
-    }
-    .sign-in-button {
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      color: white;
-      padding: 16px 40px;
-      text-decoration: none;
-      border-radius: 8px;
-      display: inline-block;
-      font-weight: 600;
-      font-size: 16px;
-      box-shadow: 0 4px 6px rgba(102, 126, 234, 0.3);
-      transition: transform 0.2s;
-    }
-    .fallback-text {
-      font-size: 13px;
-      color: #6b7280;
-      margin-top: 30px;
-      padding-top: 20px;
-      border-top: 1px solid #e5e7eb;
-    }
-    .fallback-link {
-      font-size: 12px;
-      color: #667eea;
-      word-break: break-all;
-      background-color: #f3f4f6;
-      padding: 12px;
-      border-radius: 6px;
-      display: block;
-      margin-top: 10px;
-      text-decoration: none;
-    }
-    .email-footer {
-      background-color: #f9fafb;
-      padding: 30px;
-      text-align: center;
-      border-top: 1px solid #e5e7eb;
-    }
-    .footer-text {
-      font-size: 13px;
-      color: #6b7280;
-      margin: 5px 0;
-    }
-    .security-note {
-      background-color: #fef3c7;
-      border-left: 4px solid #f59e0b;
-      padding: 15px;
-      margin: 25px 0;
-      border-radius: 4px;
-    }
-    .security-note p {
-      margin: 0;
-      font-size: 14px;
-      color: #92400e;
-    }
-  </style>
-</head>
-<body>
-  <div class="email-container">
-    <!-- Header -->
-    <div class="email-header">
-      <h1 class="logo">WORKWISE</h1>
-      <p class="subtitle">LIFT Digital Workplace Passport</p>
-    </div>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>LIFT - Access Your Workwise Account</title>
+	</head>
+	<body style="font-family: Metropolis, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #1f2937; background-color: #f3f4f6; margin: 0; padding: 0;">
+		<!-- Email Container -->
+		<table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #f3f4f6; padding-top: 60px; padding-bottom: 60px;">
+			<tr>
+				<td align="center">
+					<!-- Main Content Table -->
+					<table width="600" cellpadding="0" cellspacing="0" border="0" style="max-width: 600px; background-color: #ffffff;">
+						<!-- Header -->
+						<tr>
+							<td style="background-color: #E91E8C; padding-top: 20px; padding-right: 30px; padding-bottom: 20px; padding-left: 30px; border-top-left-radius: 8px; border-top-right-radius: 8px;">
+								<table cellpadding="0" cellspacing="0" border="0">
+									<tr>
+										<td style="padding-right: 16px; vertical-align: middle;">
+											<!-- Logo wrapper -->
+											<table cellpadding="0" cellspacing="0" border="0" style="background-color: white; border-top-left-radius: 12px; border-top-right-radius: 12px; border-bottom-left-radius: 12px; border-bottom-right-radius: 12px; padding-top: 8px; padding-right: 8px; padding-bottom: 8px; padding-left: 8px;">
+												<tr>
+													<td>
+														<img src="https://lift02.vercel.app/logo/LIFT_logo_gradient_clean.svg" alt="LIFT Logo" width="64" height="32" style="display: block; height: 32px; width: auto;" />
+													</td>
+												</tr>
+											</table>
+										</td>
+										<td style="vertical-align: middle;">
+											<h1 style="font-size: 24px; font-weight: bold; color: white; margin-top: 0; margin-right: 0; margin-bottom: 0; margin-left: 0; letter-spacing: 0;">Workwise</h1>
+										</td>
+									</tr>
+								</table>
+							</td>
+						</tr>
 
-    <!-- Body -->
-    <div class="email-body">
-      <p class="greeting">Hello,</p>
+						<!-- Body -->
+						<tr>
+							<td style="padding-top: 40px; padding-right: 30px; padding-bottom: 40px; padding-left: 30px;">
+								<p style="font-size: 18px; color: #1f2937; padding-bottom: 20px;">Hello!</p>
 
-      <p class="message">
-        You requested to sign in to your Workwise account. Click the button below to securely access your workplace passport:
-      </p>
+								<p style="font-size: 16px; color: #4b5563; padding-bottom: 30px; line-height: 1.6;">
+									Click the button below to access your Workwise workplace passport. If you're a new user,
+									this will create your account. If you're an existing user, this will sign you in.
+								</p>
 
-      <div class="button-container">
-        <a href="{{ .ConfirmationURL }}" class="sign-in-button">
-          Sign In to Workwise
-        </a>
-      </div>
+								<!-- Button -->
+								<table width="100%" cellpadding="0" cellspacing="0" border="0">
+									<tr>
+										<td align="center" style="padding-top: 5px; padding-bottom: 35px;">
+											<a href="{{ .ConfirmationURL }}" style="background-color: #E91E8C; color: white; padding-top: 16px; padding-right: 40px; padding-bottom: 16px; padding-left: 40px; text-decoration: none; display: inline-block; font-weight: 600; font-size: 16px;">Access Workwise</a>
+										</td>
+									</tr>
+								</table>
 
-      <div class="security-note">
-        <p><strong>Security:</strong> This link will expire in 1 hour for your protection.</p>
-      </div>
+								<!-- Info Box 1 -->
+								<table width="100%" cellpadding="15" cellspacing="0" border="0" style="background-color: #fdf2fb; border-left-width: 4px; border-left-style: solid; border-left-color: #E91E8C;">
+									<tr>
+										<td style="font-size: 14px; color: #831843;">
+											<strong>New here?</strong> After clicking the link above, you'll be asked to provide
+											your name and optionally your line manager's details to complete your profile.
+										</td>
+									</tr>
+								</table>
 
-      <div class="fallback-text">
-        <p>If the button above doesn't work, copy and paste this link into your browser:</p>
-        <a href="{{ .ConfirmationURL }}" class="fallback-link">{{ .ConfirmationURL }}</a>
-      </div>
-    </div>
+								<!-- Spacer -->
+								<table width="100%" cellpadding="0" cellspacing="0" border="0">
+									<tr>
+										<td style="padding-top: 15px;"></td>
+									</tr>
+								</table>
 
-    <!-- Footer -->
-    <div class="email-footer">
-      <p class="footer-text">If you didn't request this email, you can safely ignore it.</p>
-      <p class="footer-text">This email was sent by LIFT Digital Workplace Passport</p>
-    </div>
-  </div>
-</body>
+								<!-- Info Box 2 -->
+								<table width="100%" cellpadding="15" cellspacing="0" border="0" style="background-color: #fdf2fb; border-left-width: 4px; border-left-style: solid; border-left-color: #E91E8C;">
+									<tr>
+										<td style="font-size: 14px; color: #831843;">
+											<strong>Returning user?</strong> Click the link above to sign in and access your
+											workplace passport immediately.
+										</td>
+									</tr>
+								</table>
+
+								<!-- Spacer -->
+								<table width="100%" cellpadding="0" cellspacing="0" border="0">
+									<tr>
+										<td style="padding-top: 25px;"></td>
+									</tr>
+								</table>
+
+								<!-- Security Note -->
+								<table width="100%" cellpadding="15" cellspacing="0" border="0" style="background-color: #fef3c7; border-left-width: 4px; border-left-style: solid; border-left-color: #f59e0b;">
+									<tr>
+										<td style="font-size: 14px; color: #92400e;">
+											<strong>Security:</strong> This link will expire in 1 hour for your protection.
+										</td>
+									</tr>
+								</table>
+
+								<!-- Fallback Text -->
+								<table width="100%" cellpadding="0" cellspacing="0" border="0">
+									<tr>
+										<td style="padding-top: 20px; border-top-width: 1px; border-top-style: solid; border-top-color: #e5e7eb;">
+											<p style="font-size: 13px; color: #6b7280;">If the button above doesn't work, copy and paste this link into your browser:</p>
+										</td>
+									</tr>
+									<tr>
+										<td style="padding-top: 10px;">
+											<table width="100%" cellpadding="12" cellspacing="0" border="0" style="background-color: #f3f4f6;">
+												<tr>
+													<td style="font-size: 12px; color: #E91E8C;">
+														<a href="{{ .ConfirmationURL }}" style="color: #E91E8C; text-decoration: none;">{{ .ConfirmationURL }}</a>
+													</td>
+												</tr>
+											</table>
+										</td>
+									</tr>
+								</table>
+							</td>
+						</tr>
+
+						<!-- Footer -->
+						<tr>
+							<td style="background-color: #f9fafb; padding-top: 30px; padding-right: 30px; padding-bottom: 30px; padding-left: 30px; text-align: center; border-top-width: 1px; border-top-style: solid; border-top-color: #e5e7eb;">
+								<p style="font-size: 13px; color: #6b7280; padding-bottom: 5px;">If you didn't request this email, you can safely ignore it.</p>
+								<p style="font-size: 13px; color: #6b7280;">This email was sent by LIFT Digital Workplace Passport</p>
+							</td>
+						</tr>
+					</table>
+				</td>
+			</tr>
+		</table>
+	</body>
 </html>

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>LIFT - Sign In to Workwise</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      line-height: 1.6;
+      color: #1f2937;
+      background-color: #f3f4f6;
+      margin: 0;
+      padding: 20px;
+    }
+    .email-container {
+      max-width: 600px;
+      margin: 0 auto;
+      background-color: #ffffff;
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    }
+    .email-header {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      padding: 40px 30px;
+      text-align: center;
+    }
+    .logo {
+      font-size: 32px;
+      font-weight: bold;
+      color: white;
+      margin: 0 0 10px 0;
+      letter-spacing: 2px;
+    }
+    .subtitle {
+      color: rgba(255, 255, 255, 0.9);
+      font-size: 16px;
+      margin: 0;
+    }
+    .email-body {
+      padding: 40px 30px;
+    }
+    .greeting {
+      font-size: 18px;
+      color: #1f2937;
+      margin-bottom: 20px;
+    }
+    .message {
+      font-size: 16px;
+      color: #4b5563;
+      margin-bottom: 30px;
+      line-height: 1.6;
+    }
+    .button-container {
+      text-align: center;
+      margin: 35px 0;
+    }
+    .sign-in-button {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 16px 40px;
+      text-decoration: none;
+      border-radius: 8px;
+      display: inline-block;
+      font-weight: 600;
+      font-size: 16px;
+      box-shadow: 0 4px 6px rgba(102, 126, 234, 0.3);
+      transition: transform 0.2s;
+    }
+    .fallback-text {
+      font-size: 13px;
+      color: #6b7280;
+      margin-top: 30px;
+      padding-top: 20px;
+      border-top: 1px solid #e5e7eb;
+    }
+    .fallback-link {
+      font-size: 12px;
+      color: #667eea;
+      word-break: break-all;
+      background-color: #f3f4f6;
+      padding: 12px;
+      border-radius: 6px;
+      display: block;
+      margin-top: 10px;
+      text-decoration: none;
+    }
+    .email-footer {
+      background-color: #f9fafb;
+      padding: 30px;
+      text-align: center;
+      border-top: 1px solid #e5e7eb;
+    }
+    .footer-text {
+      font-size: 13px;
+      color: #6b7280;
+      margin: 5px 0;
+    }
+    .security-note {
+      background-color: #fef3c7;
+      border-left: 4px solid #f59e0b;
+      padding: 15px;
+      margin: 25px 0;
+      border-radius: 4px;
+    }
+    .security-note p {
+      margin: 0;
+      font-size: 14px;
+      color: #92400e;
+    }
+  </style>
+</head>
+<body>
+  <div class="email-container">
+    <!-- Header -->
+    <div class="email-header">
+      <h1 class="logo">WORKWISE</h1>
+      <p class="subtitle">LIFT Digital Workplace Passport</p>
+    </div>
+
+    <!-- Body -->
+    <div class="email-body">
+      <p class="greeting">Hello,</p>
+
+      <p class="message">
+        You requested to sign in to your Workwise account. Click the button below to securely access your workplace passport:
+      </p>
+
+      <div class="button-container">
+        <a href="{{ .ConfirmationURL }}" class="sign-in-button">
+          Sign In to Workwise
+        </a>
+      </div>
+
+      <div class="security-note">
+        <p><strong>Security:</strong> This link will expire in 1 hour for your protection.</p>
+      </div>
+
+      <div class="fallback-text">
+        <p>If the button above doesn't work, copy and paste this link into your browser:</p>
+        <a href="{{ .ConfirmationURL }}" class="fallback-link">{{ .ConfirmationURL }}</a>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="email-footer">
+      <p class="footer-text">If you didn't request this email, you can safely ignore it.</p>
+      <p class="footer-text">This email was sent by LIFT Digital Workplace Passport</p>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Overview

Implements production-ready authentication using Supabase magic link authentication with HTTP-only cookie sessions. Replaces the test user selection system with real user authentication, onboarding flow, and profile management.

---

## Changes

**Authentication Infrastructure**
- Implement Supabase SSR integration with HTTP-only cookie sessions for secure token storage
- Add server-side session management via `hooks.server.ts`
- Create auth callback handler supporting both PKCE and token_hash flows
- Protect dashboard routes - require authentication in production, allow dev mode for testing
- Add database trigger to auto-create profile when new user signs up

**Magic Link Flow**
- Implement email-based magic link login on landing page
- Create custom branded email template with LIFT logo and colors
- Optimize email template for client compatibility (table-based layout)
- Add clear UI distinction between login and signup flows
- Handle expired/invalid magic links with user-friendly error messages

**User Onboarding**
- Create ProfileCompletionModal for first-time users
- Collect user name (required) and line manager details (optional) on signup
- Auto-show modal when profile name is empty after authentication
- Add email and line_manager fields to profiles table

**Profile Management**
- Create ProfileSettingsModal for updating user profile information
- Add ProfileButton to footer for easy profile access
- Display logged-in user name in header
- Support updating name, email, and line manager details

**Database Changes**
- Add migration for auth-related profile fields (email, line_manager_name, line_manager_email)
- Fix RLS policies to support INSERT operations with WITH CHECK constraints
- Add unique constraint on user_id for upsert support
- Update test data scripts to include line manager information
- Fix upsertResponse to use native Supabase upsert with onConflict

**UI Improvements**
- Add Tooltip components across ActionsCRUD, QuestionCard, and UndoButton for better UX
- Add envelope icon to "Send magic link" button for clarity
- Disable email button when no public questions have been answered
- Fix TypeScript implicit 'any' types in Dash.svelte
- Improve landing page positioning and layout

**Development Experience**
- Maintain backward compatibility with test data scripts
- Allow dev mode access without authentication for local testing
- Add supabase/config.toml (removed from .gitignore for easier setup)
- Update deployment script for production auth configuration

---

## TL;DR

**For developers:**
1. Run `npm install` to get @supabase/ssr package
2. Ensure local Supabase is running: `supabase start`
3. Apply migrations: `supabase db reset`
4. Test auth flow on landing page with your email
5. Check magic link emails in Supabase Inbucket: http://localhost:54324

**Authentication flow:**
- Landing page → Enter email → Check email → Click magic link → Dashboard
- First-time users see profile completion modal
- Returning users go straight to dashboard
